### PR TITLE
Add Fuji FinePix X100

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3986,4 +3986,14 @@
 			<Hint name="ignore_bytecount" value=""/>
 		</Hints>
 	</Camera>
+	<Camera make="FUJIFILM" model="FinePix X100">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="73" y="1" width="-73" height="-1"/>
+		<Sensor black="255" white="4000"/>
+	</Camera>
 </Cameras>


### PR DESCRIPTION
The crop is the largest possible 3:2 crop without including any of
black areas.

Because of the single pixel crop at the top and bottom, which
unaligns the CFA, I had to swap the RED/BLUE positions.
