### PR TITLE
Mrw support

### DIFF
--- a/RawSpeed/MrwDecoder.cpp
+++ b/RawSpeed/MrwDecoder.cpp
@@ -1,0 +1,142 @@
+#include "StdAfx.h"
+#include "MrwDecoder.h"
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009 Klaus Post
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+    http://www.klauspost.com
+*/
+
+namespace RawSpeed {
+
+MrwDecoder::MrwDecoder(FileMap* file) :
+    RawDecoder(file) {
+  parseHeader();
+}
+
+MrwDecoder::~MrwDecoder(void) {
+}
+
+int MrwDecoder::isMRW(FileMap* input) {
+  const uchar8* data = input->getData(0);
+  return data[0] == 0x00 && data[1] == 0x4D && data[2] == 0x52 && data[3] == 0x4D;
+}
+
+#define get2BE(data,pos) ((((ushort16)(data)[pos]) << 8) | ((ushort16)(data)[pos+1]))
+
+#define get4BE(data,pos) ((((uint32)(data)[pos]) << 24) | (((uint32)(data)[pos+1]) << 16) | \
+                          (((uint32)(data)[pos+2]) << 8) | ((uint32)(data)[pos+3]))
+
+#define get8LE(data,pos) ((((uint64)(data)[pos+7]) << 56) | (((uint64)(data)[pos+6]) << 48) | \
+                          (((uint64)(data)[pos+5]) << 40) | (((uint64)(data)[pos+4]) << 32) | \
+                          (((uint64)(data)[pos+3]) << 24) | (((uint64)(data)[pos+2]) << 16) | \
+                          (((uint64)(data)[pos+1]) << 8) | ((uint64)(data)[pos]))
+                        
+/* This table includes all cameras that have ever had official MRW raw support.
+   There were also a few compacts (G400, G500, G530 and G600) that had a raw
+   mode in a hidden menu with MRW format written to JPG named files. It should
+   be easy to support them given example files but chances are it was more of a
+   novelty than something people actually used. */
+static mrw_camera_t mrw_camera_table[] = {
+  {"27820001", "DIMAGE A1"},
+  {"27200001", "DIMAGE A2"},
+  {"27470002", "DIMAGE A200"},
+  {"27730001", "DIMAGE 5"},
+  {"27660001", "DIMAGE 7"},
+  {"27790001", "DIMAGE 7I"},
+  {"27780001", "DIMAGE 7HI"},
+  {"21810002", "DYNAX 7D"},
+  {"21860002", "DYNAX 5D"},
+};
+
+void MrwDecoder::parseHeader() {
+  const unsigned char* data = mFile->getData(0);
+  
+  if (mFile->getSize() < 30)
+    ThrowRDE("Not a valid MRW file (size too small)");
+
+  if (!isMRW(mFile))
+    ThrowRDE("This isn't actually a MRW file, why are you calling me?");
+    
+  data_offset = get4BE(data,4)+8;
+  
+  // Let's just get all we need from the PRD block and be done with it
+  raw_height = get2BE(data,24);
+  raw_width = get2BE(data,26);
+  packed = (data[32] == 12);
+  cameraid = get8LE(data,16);
+  cameraName = modelName(cameraid);
+  if (!cameraName) {
+    uchar8 cameracode[9] = {0};
+    *((uint64 *) cameracode) = cameraid;
+    ThrowRDE("MRW decoder: Unknown camera with ID %s", cameracode);
+  }
+}
+
+const char* MrwDecoder::modelName(uint64 cameraid) {
+  for (uint32 i=0; i<sizeof(mrw_camera_table)/sizeof(mrw_camera_table[0]); i++) { 
+    if (*((uint64*) mrw_camera_table[i].code) == cameraid) {
+        return mrw_camera_table[i].name;
+    }
+  }
+  return NULL;
+}
+
+RawImage MrwDecoder::decodeRawInternal() {
+  uint32 imgsize;
+
+  mRaw->dim = iPoint2D(raw_width, raw_height);
+  mRaw->createData();
+
+  if (packed)
+    imgsize = raw_width * raw_height * 3 / 2;
+  else
+    imgsize = raw_width * raw_height * 2;
+
+  if (!mFile->isValid(data_offset))
+    ThrowRDE("MRW decoder: Data offset after EOF, file probably truncated");
+  if (!mFile->isValid(data_offset+imgsize-1))
+    ThrowRDE("MRW decoder: Image end after EOF, file probably truncated");
+
+  ByteStream input(mFile->getData(data_offset), imgsize);
+ 
+  try {
+    if (packed)
+      Decode12BitRawBE(input, raw_width, raw_height);
+    else
+      Decode12BitRawBEunpacked(input, raw_width, raw_height);
+  } catch (IOException &e) {
+    mRaw->setError(e.what());
+    // Let's ignore it, it may have delivered somewhat useful data.
+  }
+
+  return mRaw;
+}
+
+void MrwDecoder::checkSupportInternal(CameraMetaData *meta) {
+  this->checkCameraSupported(meta, "MINOLTA", cameraName, "");
+}
+
+void MrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
+  //Default
+  int iso = 0;
+
+  setMetaData(meta, "MINOLTA", cameraName, "", iso);
+}
+
+} // namespace RawSpeed

--- a/RawSpeed/MrwDecoder.h
+++ b/RawSpeed/MrwDecoder.h
@@ -1,0 +1,54 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009 Klaus Post
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+    http://www.klauspost.com
+*/
+#ifndef MRW_DECODER_H
+#define MRW_DECODER_H
+
+#include "RawDecoder.h"
+
+namespace RawSpeed {
+
+typedef struct {
+  const char* code;
+  const char* name;
+} mrw_camera_t;
+
+class MrwDecoder :
+  public RawDecoder
+{
+public:
+  MrwDecoder(FileMap* file);
+  virtual ~MrwDecoder(void);
+  virtual RawImage decodeRawInternal();
+  virtual void checkSupportInternal(CameraMetaData *meta);
+  virtual void decodeMetaDataInternal(CameraMetaData *meta);
+  static int isMRW(FileMap* input);
+protected:
+  virtual void parseHeader();
+  uint32 raw_width, raw_height, data_offset, packed;
+  uint64 cameraid;
+  const char* cameraName;
+  static const char* modelName(uint64 cameraid);
+};
+
+} // namespace RawSpeed
+
+#endif

--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -205,6 +205,68 @@ void RawDecoder::Decode12BitRaw(ByteStream &input, uint32 w, uint32 h) {
   }
 }
 
+void RawDecoder::Decode12BitRawBE(ByteStream &input, uint32 w, uint32 h) {
+  uchar8* data = mRaw->getData();
+  uint32 pitch = mRaw->pitch;
+  const uchar8 *in = input.getData();
+  if (input.getRemainSize() < ((w*12/8)*h)) {
+    if ((uint32)input.getRemainSize() > (w*12/8))
+      h = input.getRemainSize() / (w*12/8) - 1;
+    else
+      ThrowIOE("readUncompressedRaw: Not enough data to decode a single line. Image file truncated.");
+  }
+  for (uint32 y = 0; y < h; y++) {
+    ushort16* dest = (ushort16*) & data[y*pitch];
+    for (uint32 x = 0 ; x < w; x += 2) {
+      uint32 g1 = *in++;
+      uint32 g2 = *in++;
+      dest[x] = (g1 << 4) | (g2 >> 4);
+      uint32 g3 = *in++;
+      dest[x+1] = ((g2 & 0x0f) << 8) | g3;
+    }
+  }
+}
+
+void RawDecoder::Decode12BitRawBEunpacked(ByteStream &input, uint32 w, uint32 h) {
+  uchar8* data = mRaw->getData();
+  uint32 pitch = mRaw->pitch;
+  const uchar8 *in = input.getData();
+  if (input.getRemainSize() < w*h*2) {
+    if ((uint32)input.getRemainSize() > w*2)
+      h = input.getRemainSize() / (w*2) - 1;
+    else
+      ThrowIOE("readUncompressedRaw: Not enough data to decode a single line. Image file truncated.");
+  }
+  for (uint32 y = 0; y < h; y++) {
+    ushort16* dest = (ushort16*) & data[y*pitch];
+    for (uint32 x = 0 ; x < w; x += 1) {
+      uint32 g1 = *in++;
+      uint32 g2 = *in++;
+      dest[x] = ((g1 & 0x0f) << 8) | g2;
+    }
+  }
+}
+
+void RawDecoder::Decode12BitRawUnpacked(ByteStream &input, uint32 w, uint32 h) {
+  uchar8* data = mRaw->getData();
+  uint32 pitch = mRaw->pitch;
+  const uchar8 *in = input.getData();
+  if (input.getRemainSize() < w*h*2) {
+    if ((uint32)input.getRemainSize() > w*2)
+      h = input.getRemainSize() / (w*2) - 1;
+    else
+      ThrowIOE("readUncompressedRaw: Not enough data to decode a single line. Image file truncated.");
+  }
+  for (uint32 y = 0; y < h; y++) {
+    ushort16* dest = (ushort16*) & data[y*pitch];
+    for (uint32 x = 0 ; x < w; x += 1) {
+      uint32 g1 = *in++;
+      uint32 g2 = *in++;
+      dest[x] = ((g2 << 8) | g1) >> 4;
+    }
+  }
+}
+
 bool RawDecoder::checkCameraSupported(CameraMetaData *meta, string make, string model, string mode) {
   TrimSpaces(make);
   TrimSpaces(model);

--- a/RawSpeed/RawDecoder.h
+++ b/RawSpeed/RawDecoder.h
@@ -167,6 +167,15 @@ protected:
   /* Faster version for unpacking 12 bit LSB data */
   void Decode12BitRaw(ByteStream &input, uint32 w, uint32 h);
 
+  /* Faster version for unpacking 12 bit MSB data */
+  void Decode12BitRawBE(ByteStream &input, uint32 w, uint32 h);
+
+  /* Faster version for reading unpacked 12 bit MSB data */
+  void Decode12BitRawBEunpacked(ByteStream &input, uint32 w, uint32 h);
+
+  /* Faster version for reading unpacked 12 bit LSB data */
+  void Decode12BitRawUnpacked(ByteStream &input, uint32 w, uint32 h);
+
   /* Generic decompressor for uncompressed images */
   /* order: Order of the bits - see Common.h for possibilities. */
   void decodeUncompressed(TiffIFD *rawIFD, BitOrder order);

--- a/RawSpeed/RawParser.cpp
+++ b/RawSpeed/RawParser.cpp
@@ -5,6 +5,7 @@
 #include "X3fParser.h"
 #include "ByteStreamSwap.h"
 #include "TiffEntryBE.h"
+#include "MrwDecoder.h"
 
 /*
     RawSpeed - RAW file decoder.
@@ -44,6 +45,14 @@ RawDecoder* RawParser::getDecoder() {
   // For now it is 104 bytes for RAF images.
   if (mInput->getSize() <=  104)
     ThrowRDE("File too small");
+
+  // MRW images are easy to check for, let's try that first
+  if (MrwDecoder::isMRW(mInput)) {
+    try {
+      return new MrwDecoder(mInput);
+    } catch (RawDecoderException) {
+    }
+  }
 
   // FUJI has pointers to IFD's at fixed byte offsets
   // So if camera is FUJI, we cannot use ordinary TIFF parser

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4103,4 +4103,94 @@
 		<Crop x="73" y="1" width="-73" height="-1"/>
 		<Sensor black="255" white="4000"/>
 	</Camera>
+	<Camera make="MINOLTA" model="DYNAX 5D">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+	</Camera>
+  <Camera make="MINOLTA" model="DYNAX 7D">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+	</Camera>
+	<Camera make="MINOLTA" model="DIMAGE A1">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3965"/>
+	</Camera>
+	<Camera make="MINOLTA" model="DIMAGE A2">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3965"/>
+	</Camera>
+	<Camera make="MINOLTA" model="DIMAGE A200">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3965"/>
+	</Camera>
+	<Camera make="MINOLTA" model="DIMAGE 5">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3965"/>
+	</Camera>
+	<Camera make="MINOLTA" model="DIMAGE 7">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3965"/>
+	</Camera>
+	<Camera make="MINOLTA" model="DIMAGE 7I">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3965"/>
+	</Camera>
+	<Camera make="MINOLTA" model="DIMAGE 7HI">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3965"/>
+	</Camera>
 </Cameras>


### PR DESCRIPTION
Support for all the MRW producing cameras from Minolta and Konica Minolta. This code has been tested with and is currently merged into the master version of darktable. It has been tested against example files of all the MRW producing cameras. 

The only cameras not supported by this are a few G-series compacts that had a hidden menu item to enable MRW support. Chances are there are very few of those files in existance and adding support for them is trivial given some example files.
