### PR TITLE
Sony A100 support

### DIFF
--- a/RawSpeed/ArwDecoder.cpp
+++ b/RawSpeed/ArwDecoder.cpp
@@ -27,6 +27,7 @@ namespace RawSpeed {
 ArwDecoder::ArwDecoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
   mShiftDownScale = 0;
+  decoderVersion = 1;
 }
 
 ArwDecoder::~ArwDecoder(void) {

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3669,15 +3669,14 @@
 			<Vertical x="6032" width="14"/>
 		</BlackAreas>
 	</Camera>
-	<Camera make="SONY" model="DSLR-A100" supported="no">
-		<!-- Files doesn't have a valid TIFF structure -->
+	<Camera make="SONY" model="DSLR-A100">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
 			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
-		<Crop x="0" y="0" width="3880" height="2600"/>
+		<Crop x="0" y="0" width="-1" height="-2"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A200">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3669,7 +3669,7 @@
 			<Vertical x="6032" width="14"/>
 		</BlackAreas>
 	</Camera>
-	<Camera make="SONY" model="DSLR-A100">
+	<Camera make="SONY" model="DSLR-A100" decoder_version="1">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>


### PR DESCRIPTION
Support the Sony A100. It's a bastard ARW format where most of the format is the normal TIFF-based ARW but the actual data is outside the TIFF in an offset indicated in one of the TIFF fields.
