### PR TITLE
Add support for the Sony R1 camera

### DIFF
--- a/RawSpeed/ArwDecoder.cpp
+++ b/RawSpeed/ArwDecoder.cpp
@@ -4,6 +4,7 @@
     RawSpeed - RAW file decoder.
 
     Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -70,6 +71,16 @@ RawImage ArwDecoder::decodeRawInternal() {
 
   TiffIFD* raw = data[0];
   int compression = raw->getEntry(COMPRESSION)->getInt();
+  if (1 == compression) {
+    // This is probably the SR2 format, let's pass it on
+    try {
+      DecodeSR2(raw);
+    } catch (IOException &e) {
+      mRaw->setError(e.what());
+    }
+
+    return mRaw;
+  }
   if (32767 != compression)
     ThrowRDE("ARW Decoder: Unsupported compression");
 
@@ -143,6 +154,19 @@ RawImage ArwDecoder::decodeRawInternal() {
   }
 
   return mRaw;
+}
+
+void ArwDecoder::DecodeSR2(TiffIFD* raw) {
+  uint32 width = raw->getEntry(IMAGEWIDTH)->getInt();
+  uint32 height = raw->getEntry(IMAGELENGTH)->getInt();
+  uint32 off = raw->getEntry(STRIPOFFSETS)->getInt();
+  uint32 c2 = raw->getEntry(STRIPBYTECOUNTS)->getInt();
+
+  mRaw->dim = iPoint2D(width, height);
+  mRaw->createData();
+  ByteStream input(mFile->getData(off), c2);
+
+  Decode14BitRawBEunpacked(input, width, height);
 }
 
 void ArwDecoder::DecodeARW(ByteStream &input, uint32 w, uint32 h) {

--- a/RawSpeed/ArwDecoder.h
+++ b/RawSpeed/ArwDecoder.h
@@ -2,6 +2,7 @@
     RawSpeed - RAW file decoder.
 
     Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -43,6 +44,7 @@ public:
 protected:
   void DecodeARW(ByteStream &input, uint32 w, uint32 h);
   void DecodeARW2(ByteStream &input, uint32 w, uint32 h, uint32 bpp);
+  void DecodeSR2(TiffIFD* raw);
   TiffIFD *mRootIFD;
   uint32 curve[0x4001];
   ByteStream *in;

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4392,4 +4392,14 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
 	</Camera>
+	<Camera make="SONY" model="DSC-R1">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-60" height="0"/>
+		<Sensor black="511" white="16383"/>
+	</Camera>
 </Cameras>


### PR DESCRIPTION
The R1 raws are not ARW format but since the camera is a "SONY" the tiff parsing creates an ArwDecoder. The format is simple enough that I just special cased it there.
