### PR TITLE
Add support for the Mamiya ZD

### DIFF
--- a/RawSpeed/MefDecoder.cpp
+++ b/RawSpeed/MefDecoder.cpp
@@ -1,0 +1,78 @@
+#include "StdAfx.h"
+#include "MefDecoder.h"
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+    http://www.klauspost.com
+*/
+
+namespace RawSpeed {
+
+MefDecoder::MefDecoder(TiffIFD *rootIFD, FileMap* file)  :
+    RawDecoder(file), mRootIFD(rootIFD) {
+  decoderVersion = 0;
+}
+
+MefDecoder::~MefDecoder(void) {
+}
+
+RawImage MefDecoder::decodeRawInternal() {
+  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(STRIPOFFSETS);
+
+  if (data.size() < 2)
+    ThrowRDE("MEF Decoder: No image data found");
+    
+  TiffIFD* raw = data[1];
+  uint32 width = raw->getEntry(IMAGEWIDTH)->getInt();
+  uint32 height = raw->getEntry(IMAGELENGTH)->getInt();
+  uint32 off = raw->getEntry(STRIPOFFSETS)->getInt();
+  uint32 c2 = raw->getEntry(STRIPBYTECOUNTS)->getInt();
+
+  mRaw->dim = iPoint2D(width, height);
+  mRaw->createData();
+  ByteStream input(mFile->getData(off), c2);
+
+  Decode12BitRawBE(input, width, height);
+  return mRaw;
+}
+
+void MefDecoder::checkSupportInternal(CameraMetaData *meta) {
+  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
+  if (data.empty())
+    ThrowRDE("MEF Support check: Model name not found");
+  string make = data[0]->getEntry(MAKE)->getString();
+  string model = data[0]->getEntry(MODEL)->getString();
+  this->checkCameraSupported(meta, make, model, "");
+}
+
+void MefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
+  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
+
+  if (data.empty())
+    ThrowRDE("ARW Meta Decoder: Model name found");
+  if (!data[0]->hasEntry(MAKE))
+    ThrowRDE("ARW Decoder: Make name not found");
+
+  string make = data[0]->getEntry(MAKE)->getString();
+  string model = data[0]->getEntry(MODEL)->getString();
+  setMetaData(meta, make, model, "", 0);
+}
+
+} // namespace RawSpeed

--- a/RawSpeed/MefDecoder.cpp
+++ b/RawSpeed/MefDecoder.cpp
@@ -66,9 +66,9 @@ void MefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 
   if (data.empty())
-    ThrowRDE("ARW Meta Decoder: Model name found");
+    ThrowRDE("MEF Decoder: Model name found");
   if (!data[0]->hasEntry(MAKE))
-    ThrowRDE("ARW Decoder: Make name not found");
+    ThrowRDE("MEF Decoder: Make name not found");
 
   string make = data[0]->getEntry(MAKE)->getString();
   string model = data[0]->getEntry(MODEL)->getString();

--- a/RawSpeed/MefDecoder.h
+++ b/RawSpeed/MefDecoder.h
@@ -1,0 +1,45 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+    http://www.klauspost.com
+*/
+#ifndef MEF_DECODER_H
+#define MEF_DECODER_H
+
+#include "RawDecoder.h"
+
+namespace RawSpeed {
+
+class MefDecoder :
+  public RawDecoder
+{
+public:
+  MefDecoder(TiffIFD *rootIFD, FileMap* file);
+  virtual ~MefDecoder(void);
+  virtual RawImage decodeRawInternal();
+  virtual void checkSupportInternal(CameraMetaData *meta);
+  virtual void decodeMetaDataInternal(CameraMetaData *meta);
+protected:
+  TiffIFD *mRootIFD;
+};
+
+} // namespace RawSpeed
+
+#endif

--- a/RawSpeed/TiffParser.cpp
+++ b/RawSpeed/TiffParser.cpp
@@ -160,6 +160,10 @@ RawDecoder* TiffParser::getDecoder() {
         mRootIFD = NULL;
         return new SrwDecoder(root, mInput);
       }
+      if (!make.compare("Mamiya-OP Co.,Ltd.")) {
+        mRootIFD = NULL;
+        return new MefDecoder(root, mInput);
+      }
     }
   }
   throw TiffParserException("No decoder found. Sorry.");

--- a/RawSpeed/TiffParser.h
+++ b/RawSpeed/TiffParser.h
@@ -37,6 +37,7 @@
 #include "RafDecoder.h"
 #include "Rw2Decoder.h"
 #include "SrwDecoder.h"
+#include "MefDecoder.h"
 
 namespace RawSpeed {
 

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4591,4 +4591,14 @@
 		<Crop x="0" y="0" width="-60" height="0"/>
 		<Sensor black="511" white="16383"/>
 	</Camera>
+	<Camera make="Mamiya-OP Co.,Ltd." model="MAMIYA ZD">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4000"/>
+	</Camera>
 </Cameras>


### PR DESCRIPTION
As it turns out the Mamiya MEF files are pretty standard Tiffs with a 12bit packed encoding. It was just a matter of plumbing things through to get a working decoder.
