### PR TITLE
Add support for the Pentax K100D Super and *ist D

### DIFF
--- a/RawSpeed/PefDecoder.cpp
+++ b/RawSpeed/PefDecoder.cpp
@@ -45,7 +45,7 @@ RawImage PefDecoder::decodeRawInternal() {
 
   int compression = raw->getEntry(COMPRESSION)->getInt();
 
-  if (1 == compression) {
+  if (1 == compression || compression == 32773) {
     decodeUncompressed(raw, BitOrder_Jpeg);
     return mRaw;
   }

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3508,6 +3508,16 @@
 		<Crop x="0" y="0" width="3040" height="2024"/>
 		<Sensor black="127" white="3950"/>
 	</Camera>
+	<Camera make="PENTAX Corporation" model="PENTAX K100D Super">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="127" white="4095"/>
+	</Camera>
 	<Camera make="PENTAX" model="PENTAX K100D">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3517,6 +3527,16 @@
 		</CFA>
 		<Crop x="0" y="0" width="3040" height="2024"/>
 		<Sensor black="127" white="3950"/>
+	</Camera>
+	<Camera make="PENTAX Corporation" model="PENTAX *ist D">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="128" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX K10D">
 		<CFA width="2" height="2">


### PR DESCRIPTION
Add two old pentax cameras. Both were tested in darktable against samples from rawsamples.ch. For one of them a new compression type needed to be recognized but the decoding is the same uncompressed one that was already there.
