### PR TITLE
Add a decoder for the Leaf .MOS format

### DIFF
--- a/RawSpeed/MosDecoder.cpp
+++ b/RawSpeed/MosDecoder.cpp
@@ -1,0 +1,96 @@
+#include "StdAfx.h"
+#include "MosDecoder.h"
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+    http://www.klauspost.com
+*/
+
+namespace RawSpeed {
+
+MosDecoder::MosDecoder(TiffIFD *rootIFD, FileMap* file)  :
+    RawDecoder(file), mRootIFD(rootIFD) {
+  decoderVersion = 0;
+
+  TiffEntry *xmp = mRootIFD->getEntryRecursive(XMP);
+  if (!xmp)
+    ThrowRDE("MOS Decoder: Couldn't find the XMP");
+
+  parseXMP(xmp);
+}
+
+MosDecoder::~MosDecoder(void) {
+}
+
+void MosDecoder::parseXMP(TiffEntry *xmp) {
+  uchar8 *text = xmp->getDataWrt();
+  text[xmp->count - 1] = 0; // Make sure the string is NUL terminated
+
+  char *makeEnd;
+  make = strstr((char *) text, "<tiff:Make>");
+  makeEnd = strstr((char *) text, "</tiff:Make>");
+  if (!make || !makeEnd)
+    ThrowRDE("MOS Decoder: Couldn't find the Make in the XMP");
+  make += 11; // Advance to the end of the start tag
+
+  char *modelEnd;
+  model = strstr((char *) text, "<tiff:Model>");
+  modelEnd = strstr((char *) text, "</tiff:Model>");
+  if (!model || !modelEnd)
+    ThrowRDE("MOS Decoder: Couldn't find the Model in the XMP");
+  model += 12; // Advance to the end of the start tag
+
+  // NUL terminate the strings in place
+  *makeEnd = 0;
+  *modelEnd = 0;
+}
+
+RawImage MosDecoder::decodeRawInternal() {
+  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(TILEOFFSETS);
+
+  if (data.empty())
+    ThrowRDE("MOS Decoder: No image data found");
+
+  int compression = data[0]->getEntry(COMPRESSION)->getInt();
+  if (1 != compression)
+    ThrowRDE("MOS Decoder: Unsupported compression");
+
+  TiffIFD* raw = data[0];
+  uint32 width = raw->getEntry(IMAGEWIDTH)->getInt();
+  uint32 height = raw->getEntry(IMAGELENGTH)->getInt();
+  uint32 off = raw->getEntry(TILEOFFSETS)->getInt();
+
+  mRaw->dim = iPoint2D(width, height);
+  mRaw->createData();
+  ByteStream input(mFile->getData(off), mFile->getSize()-off);
+
+  Decode16BitRawBEunpacked(input, width, height);
+  return mRaw;
+}
+
+void MosDecoder::checkSupportInternal(CameraMetaData *meta) {
+  this->checkCameraSupported(meta, make, model, "");
+}
+
+void MosDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
+  setMetaData(meta, make, model, "", 0);
+}
+
+} // namespace RawSpeed

--- a/RawSpeed/MosDecoder.cpp
+++ b/RawSpeed/MosDecoder.cpp
@@ -33,26 +33,28 @@ MosDecoder::MosDecoder(TiffIFD *rootIFD, FileMap* file)  :
   if (!xmp)
     ThrowRDE("MOS Decoder: Couldn't find the XMP");
 
+  xmpText = NULL;
   parseXMP(xmp);
 }
 
 MosDecoder::~MosDecoder(void) {
+  delete xmpText;
 }
 
 void MosDecoder::parseXMP(TiffEntry *xmp) {
-  uchar8 *text = xmp->getDataWrt();
-  text[xmp->count - 1] = 0; // Make sure the string is NUL terminated
+  xmpText = xmp->getDataWrt();
+  xmpText[xmp->count - 1] = 0; // Make sure the string is NUL terminated
 
   char *makeEnd;
-  make = strstr((char *) text, "<tiff:Make>");
-  makeEnd = strstr((char *) text, "</tiff:Make>");
+  make = strstr((char *) xmpText, "<tiff:Make>");
+  makeEnd = strstr((char *) xmpText, "</tiff:Make>");
   if (!make || !makeEnd)
     ThrowRDE("MOS Decoder: Couldn't find the Make in the XMP");
   make += 11; // Advance to the end of the start tag
 
   char *modelEnd;
-  model = strstr((char *) text, "<tiff:Model>");
-  modelEnd = strstr((char *) text, "</tiff:Model>");
+  model = strstr((char *) xmpText, "<tiff:Model>");
+  modelEnd = strstr((char *) xmpText, "</tiff:Model>");
   if (!model || !modelEnd)
     ThrowRDE("MOS Decoder: Couldn't find the Model in the XMP");
   model += 12; // Advance to the end of the start tag

--- a/RawSpeed/MosDecoder.cpp
+++ b/RawSpeed/MosDecoder.cpp
@@ -42,6 +42,9 @@ MosDecoder::~MosDecoder(void) {
 }
 
 void MosDecoder::parseXMP(TiffEntry *xmp) {
+  if (xmp->count <= 0)
+    ThrowRDE("MOS Decoder: Empty XMP");
+
   xmpText = xmp->getDataWrt();
   xmpText[xmp->count - 1] = 0; // Make sure the string is NUL terminated
 

--- a/RawSpeed/MosDecoder.h
+++ b/RawSpeed/MosDecoder.h
@@ -1,0 +1,48 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+    http://www.klauspost.com
+*/
+#ifndef MOS_DECODER_H
+#define MOS_DECODER_H
+
+#include "RawDecoder.h"
+#include "string.h"
+
+namespace RawSpeed {
+
+class MosDecoder :
+  public RawDecoder
+{
+public:
+  MosDecoder(TiffIFD *rootIFD, FileMap* file);
+  virtual ~MosDecoder(void);
+  virtual RawImage decodeRawInternal();
+  virtual void checkSupportInternal(CameraMetaData *meta);
+  virtual void decodeMetaDataInternal(CameraMetaData *meta);
+protected:
+  TiffIFD *mRootIFD;
+  char *make, *model;
+  void parseXMP(TiffEntry *xmp);
+};
+
+} // namespace RawSpeed
+
+#endif

--- a/RawSpeed/MosDecoder.h
+++ b/RawSpeed/MosDecoder.h
@@ -40,6 +40,7 @@ public:
 protected:
   TiffIFD *mRootIFD;
   char *make, *model;
+  uchar8 *xmpText;
   void parseXMP(TiffEntry *xmp);
 };
 

--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -346,6 +346,26 @@ void RawDecoder::Decode14BitRawBEunpacked(ByteStream &input, uint32 w, uint32 h)
   }
 }
 
+void RawDecoder::Decode16BitRawBEunpacked(ByteStream &input, uint32 w, uint32 h) {
+  uchar8* data = mRaw->getData();
+  uint32 pitch = mRaw->pitch;
+  const uchar8 *in = input.getData();
+  if (input.getRemainSize() < w*h*2) {
+    if ((uint32)input.getRemainSize() > w*2)
+      h = input.getRemainSize() / (w*2) - 1;
+    else
+      ThrowIOE("readUncompressedRaw: Not enough data to decode a single line. Image file truncated.");
+  }
+  for (uint32 y = 0; y < h; y++) {
+    ushort16* dest = (ushort16*) & data[y*pitch];
+    for (uint32 x = 0 ; x < w; x += 1) {
+      uint32 g1 = *in++;
+      uint32 g2 = *in++;
+      dest[x] = (g1 << 8) | g2;
+    }
+  }
+}
+
 void RawDecoder::Decode12BitRawUnpacked(ByteStream &input, uint32 w, uint32 h) {
   uchar8* data = mRaw->getData();
   uint32 pitch = mRaw->pitch;

--- a/RawSpeed/RawDecoder.h
+++ b/RawSpeed/RawDecoder.h
@@ -186,6 +186,9 @@ protected:
   /* Faster version for reading unpacked 14 bit MSB data */
   void Decode14BitRawBEunpacked(ByteStream &input, uint32 w, uint32 h);
 
+  /* Faster version for reading unpacked 16 bit MSB data */
+  void Decode16BitRawBEunpacked(ByteStream &input, uint32 w, uint32 h);
+
   /* Faster version for reading unpacked 12 bit LSB data */
   void Decode12BitRawUnpacked(ByteStream &input, uint32 w, uint32 h);
 

--- a/RawSpeed/TiffParser.cpp
+++ b/RawSpeed/TiffParser.cpp
@@ -166,6 +166,17 @@ RawDecoder* TiffParser::getDecoder() {
       }
     }
   }
+
+  potentials = mRootIFD->getIFDsWithTag(SOFTWARE);
+  if (!potentials.empty()) {
+    string software = potentials[0]->getEntry(SOFTWARE)->getString();
+    TrimSpaces(software);
+    if (!software.compare("Camera Library")) {
+      mRootIFD = NULL;
+      return new MosDecoder(root, mInput);
+    }
+  }
+
   throw TiffParserException("No decoder found. Sorry.");
   return NULL;
 }

--- a/RawSpeed/TiffParser.h
+++ b/RawSpeed/TiffParser.h
@@ -38,6 +38,7 @@
 #include "Rw2Decoder.h"
 #include "SrwDecoder.h"
 #include "MefDecoder.h"
+#include "MosDecoder.h"
 
 namespace RawSpeed {
 

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4739,4 +4739,14 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4000"/>
 	</Camera>
+	<Camera make="Creo/Leaf" model="Leaf Aptus 22(LF3779     )/Hasselblad H1">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="16191"/>
+	</Camera>
 </Cameras>


### PR DESCRIPTION
A decoder for the Leaf MOS format, tested against the Leaf Aptus 22 file available on rawsamples.ch. The format turns out to be mostly a straight 16 bit tiff. The difficult thing is that the metadata is almost all in a XMP blob inside the tiff. I "parsed" enough of it to get the make and model out. Using the full XML library is probably a bad idea here as it exposes too much code to potentially hostile files. I did a very simple strstr() based search for the tiff:Make and tiff:Model tags and used their values in place.
