### PR TITLE
Remove now unused bytecount from the DCR decoder

### DIFF
--- a/RawSpeed/DcrDecoder.cpp
+++ b/RawSpeed/DcrDecoder.cpp
@@ -44,7 +44,6 @@ RawImage DcrDecoder::decodeRawInternal() {
   uint32 width = raw->getEntry(IMAGEWIDTH)->getInt();
   uint32 height = raw->getEntry(IMAGELENGTH)->getInt();
   uint32 off = raw->getEntry(STRIPOFFSETS)->getInt();
-  uint32 c2 = raw->getEntry(STRIPBYTECOUNTS)->getInt();
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();


### PR DESCRIPTION
Now that you've fixed the way I handled the bytecount for the DCR decoder the c2 variable is no longer needed. I considered adding a check liked you did in ErfDecoder but since that's already caught later we may as well ignore it.
