### PR TITLE
rawspeed: fix new build warnings

### DIFF
--- a/RawSpeed/HasselbladDecompressor.cpp
+++ b/RawSpeed/HasselbladDecompressor.cpp
@@ -117,9 +117,6 @@ inline int HasselbladDecompressor::getBits(int len) {
 }
 
 void HasselbladDecompressor::decodeScanHasselblad() {
-  // Hasselblad has a single huffman table
-  HuffmanTable *dctbl1 = &huff[frame.compInfo[0].dcTblNo];
-
   // Pixels are packed two at a time, not like LJPEG:
   // [p1_length_as_huffman][p2_length_as_huffman][p0_diff_with_length][p1_diff_with_length]|NEXT PIXELS
   for (uint32 y = 0; y < frame.h; y++) {
@@ -139,7 +136,7 @@ void HasselbladDecompressor::decodeScanHasselblad() {
 }
 
 int HasselbladDecompressor::HuffGetLength() {
-  int rv;
+  int rv = 0;
   int l, temp;
   int code, val;
 

--- a/RawSpeed/ThreefrDecoder.cpp
+++ b/RawSpeed/ThreefrDecoder.cpp
@@ -45,7 +45,6 @@ RawImage ThreefrDecoder::decodeRawInternal() {
   uint32 width = raw->getEntry(IMAGEWIDTH)->getInt();
   uint32 height = raw->getEntry(IMAGELENGTH)->getInt();
   uint32 off = raw->getEntry(STRIPOFFSETS)->getInt();
-  uint32 c2 = raw->getEntry(STRIPBYTECOUNTS)->getInt();
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();


### PR DESCRIPTION
dctbl1/c2 are unused variables.
rv caused a warning about being a potentially uninitialized variable.
