### PR TITLE
Comment out an unused constant

### DIFF
--- a/RawSpeed/X3fParser.cpp
+++ b/RawSpeed/X3fParser.cpp
@@ -205,7 +205,8 @@ typedef unsigned char   Boolean; /* 0 or 1 */
 
 static const int halfShift  = 10; /* used for shifting by 10 bits */
 static const UTF32 halfBase = 0x0010000UL;
-static const UTF32 halfMask = 0x3FFUL;
+// This isn't used and clang will issue a warning about it
+//static const UTF32 halfMask = 0x3FFUL;
 static const UTF8 firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 
 static bool ConvertUTF16toUTF8 (const UTF16** sourceStart, const UTF16* sourceEnd,  UTF8** targetStart, UTF8* targetEnd) 

--- a/RawSpeed/X3fParser.cpp
+++ b/RawSpeed/X3fParser.cpp
@@ -205,8 +205,6 @@ typedef unsigned char   Boolean; /* 0 or 1 */
 
 static const int halfShift  = 10; /* used for shifting by 10 bits */
 static const UTF32 halfBase = 0x0010000UL;
-// This isn't used and clang will issue a warning about it
-//static const UTF32 halfMask = 0x3FFUL;
 static const UTF8 firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 
 static bool ConvertUTF16toUTF8 (const UTF16** sourceStart, const UTF16* sourceEnd,  UTF8** targetStart, UTF8* targetEnd) 


### PR DESCRIPTION
Clang complains this constant is unused. I commented it out but I suppose it could also be removed completely if there's no reason it may be needed in the future.
