### PR TITLE
Fix SRW compression decoding and add the newer SRW compression format

### DIFF
--- a/RawSpeed/SrwDecoder.cpp
+++ b/RawSpeed/SrwDecoder.cpp
@@ -181,6 +181,19 @@ void SrwDecoder::decodeCompressed( TiffIFD* raw )
       img_up2 += 16;
     }
   }
+
+  // Swap red and blue pixels to get the final CFA pattern
+  for (uint32 y = 0; y < height-1; y+=2) {
+    ushort16* topline = (ushort16*)mRaw->getData(0, y);
+    ushort16* bottomline = (ushort16*)mRaw->getData(0, y+1);
+    for (uint32 x = 0; x < width-1; x += 2) {
+      ushort16 temp = topline[1];
+      topline[1] = bottomline[0];
+      bottomline[0] = temp;
+      topline += 2;
+      bottomline += 2;
+    }
+  }
 }
 
 

--- a/RawSpeed/SrwDecoder.cpp
+++ b/RawSpeed/SrwDecoder.cpp
@@ -56,7 +56,7 @@ RawImage SrwDecoder::decodeRawInternal() {
   int compression = raw->getEntry(COMPRESSION)->getInt();
   int bits = raw->getEntry(BITSPERSAMPLE)->getInt();
 
-  if (32769 != compression && 32770 != compression )
+  if (32769 != compression && 32770 != compression && 32772 != compression)
     ThrowRDE("Srw Decoder: Unsupported compression");
 
   if (32769 == compression)
@@ -89,6 +89,18 @@ RawImage SrwDecoder::decodeRawInternal() {
       }
       return mRaw;
     }
+  }
+  if (32772 == compression)
+  {
+    uint32 nslices = raw->getEntry(STRIPOFFSETS)->count;
+    if (nslices != 1)
+      ThrowRDE("Srw Decoder: Only one slice supported, found %u", nslices);
+    try {
+      decodeCompressed2(raw, bits);
+    } catch (RawDecoderException& e) {
+      mRaw->setError(e.what());
+    }
+    return mRaw;
   }
   ThrowRDE("Srw Decoder: Unsupported compression");
   return mRaw;
@@ -195,6 +207,87 @@ void SrwDecoder::decodeCompressed( TiffIFD* raw )
     }
   }
 }
+
+// Decoder for compressed srw files (NX3000 and later)
+void SrwDecoder::decodeCompressed2( TiffIFD* raw, int bits)
+{
+  uint32 width = raw->getEntry(IMAGEWIDTH)->getInt();
+  uint32 height = raw->getEntry(IMAGELENGTH)->getInt();
+  uint32 offset = raw->getEntry(STRIPOFFSETS)->getInt();
+
+  mRaw->dim = iPoint2D(width, height);
+  mRaw->createData();
+
+  const ushort16 tab[14] = { 0x304,0x307,0x206,0x205,0x403,0x600,0x709,
+                             0x80a,0x90b,0xa0c,0xa0d,0x501,0x408,0x402 };
+  ushort16 huff[1026], vpred[2][2] = {{0,0},{0,0}}, hpred[2];
+
+  uint32 n = 0;
+  huff[n] = 10;
+  for (uint32 i=0; i < 14; i++)
+    for(int32 c = 0; c < (1024 >> (tab[i] >> 8)); c++)
+      huff[++n] = tab[i];
+
+  ByteStream input(mFile->getData(offset), mFile->getSize());
+  getbithuff(input, -1, NULL);
+
+  for (uint32 y = 0; y < height; y++) {
+    ushort16* img = (ushort16*)mRaw->getData(0, y);
+    for (uint32 x = 0; x < width; x++) {
+      int32 diff = ljpegDiff(input, huff);
+      if (x < 2)
+        hpred[x] = vpred[y & 1][x] += diff;
+      else
+        hpred[x & 1] += diff;
+      img[x] = hpred[x & 1];
+      if (img[x] >> bits)
+        ThrowRDE("SRW: Error: decoded value out of bounds");
+    }
+  }
+}
+
+int32 SrwDecoder::ljpegDiff (ByteStream &input, ushort16 *huff)
+{
+  int32 len, diff;
+
+  len = getbithuff(input, *huff, huff+1);
+  if (len == 16)
+    return -32768;
+  diff = getbithuff(input, len, NULL);
+  if ((diff & (1 << (len-1))) == 0)
+    diff -= (1 << len) - 1;
+  return diff;
+}
+
+uint32 SrwDecoder::getbithuff (ByteStream &input, int nbits, ushort16 *huff)
+{
+  static unsigned bitbuf=0;
+  static int vbits=0, reset=0;
+  uint32 c;
+
+  if (nbits > 25) return 0;
+  if (nbits < 0)
+    return bitbuf = vbits = reset = 0;
+  if (nbits == 0 || vbits < 0) return 0;
+  // The <1000 comparison is spurious and will always return true as the value 
+  // is a byte converted to uint32. It used to be != EOF in dcraw when using fgetc
+  // but doesn't make sense with getByte as that will throw an exception instead
+  while (!reset && vbits < nbits && (c = ((uint32)input.getByte())) < 1000 &&
+    !(reset = 0 && c == 0xff && ((uint32) input.getByte()))) {
+    bitbuf = (bitbuf << 8) + (uchar8) c;
+    vbits += 8;
+  }
+  c = bitbuf << (32-vbits) >> (32-nbits);
+  if (huff) {
+    vbits -= huff[c] >> 8;
+    c = (uchar8) huff[c];
+  } else
+    vbits -= nbits;
+  if (vbits < 0)
+    ThrowRDE("CRW: Asking for bits we don't have");
+  return c;
+}
+
 
 
 void SrwDecoder::checkSupportInternal(CameraMetaData *meta) {

--- a/RawSpeed/SrwDecoder.h
+++ b/RawSpeed/SrwDecoder.h
@@ -41,10 +41,14 @@ public:
   virtual void checkSupportInternal(CameraMetaData *meta);
   virtual TiffIFD* getRootIFD() {return mRootIFD;}
 private:
+  typedef struct {
+    uchar8 encLen;
+    uchar8 diffLen;
+  } encTableItem;
+
   void decodeCompressed(TiffIFD* raw);
   void decodeCompressed2(TiffIFD* raw, int bits);
-  int32 ljpegDiff (BitPumpMSB &pump, ushort16 *huff);
-  uint32 getbithuff (BitPumpMSB &pump, int nbits, ushort16 *huff);
+  int32 samsungDiff (BitPumpMSB &pump, encTableItem *tbl);
   TiffIFD *mRootIFD;
   ByteStream *b;
 };

--- a/RawSpeed/SrwDecoder.h
+++ b/RawSpeed/SrwDecoder.h
@@ -43,8 +43,8 @@ public:
 private:
   void decodeCompressed(TiffIFD* raw);
   void decodeCompressed2(TiffIFD* raw, int bits);
-  int32 ljpegDiff (ByteStream &input, ushort16 *huff);
-  uint32 getbithuff (ByteStream &input, int nbits, ushort16 *huff);
+  int32 ljpegDiff (BitPumpMSB &pump, ushort16 *huff);
+  uint32 getbithuff (BitPumpMSB &pump, int nbits, ushort16 *huff);
   TiffIFD *mRootIFD;
   ByteStream *b;
 };

--- a/RawSpeed/SrwDecoder.h
+++ b/RawSpeed/SrwDecoder.h
@@ -41,7 +41,10 @@ public:
   virtual void checkSupportInternal(CameraMetaData *meta);
   virtual TiffIFD* getRootIFD() {return mRootIFD;}
 private:
-  void decodeCompressed( TiffIFD* raw);
+  void decodeCompressed(TiffIFD* raw);
+  void decodeCompressed2(TiffIFD* raw, int bits);
+  int32 ljpegDiff (ByteStream &input, ushort16 *huff);
+  uint32 getbithuff (ByteStream &input, int nbits, ushort16 *huff);
   TiffIFD *mRootIFD;
   ByteStream *b;
 };

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3824,8 +3824,8 @@
 	<Camera make="SAMSUNG" model="NX2000" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="45" y="25" width="-11" height="-29"/>
@@ -3834,8 +3834,8 @@
 	<Camera make="SAMSUNG" model="NX30" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="45" y="25" width="-11" height="-29"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3844,8 +3844,8 @@
 	<Camera make="SAMSUNG" model="NX300" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="45" y="25" width="-11" height="-29"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3851,6 +3851,16 @@
 		<Crop x="45" y="25" width="-11" height="-29"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
+	<Camera make="SAMSUNG" model="NX3000">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="96" y="42" width="-32" height="-24"/>
+		<Sensor black="0" white="4095"/>
+	</Camera>
 	<Camera make="SAMSUNG" model="EK-GN120" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>


### PR DESCRIPTION
The SRW decoding method didn't include the final red/blue swap present in dcraw. Not doing the swap and setting the CFA pattern accordingly generates red/blue fringing. An example file that shows this:

https://encrypted.pcode.nl/files/temp/07220006.SRW

The simple solution is to do a final swap of the red/blue pixels and change the CFA pattern to match. There may be a better way of doing it though, that doesn't require the extra step.
