### PR TITLE
Support for original D1/D1s .TIF raw files

### DIFF
--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -1,6 +1,7 @@
 #include "StdAfx.h"
 #include "Cr2Decoder.h"
 #include "TiffParserHeaderless.h"
+#include "ByteStreamSwap.h"
 
 /*
     RawSpeed - RAW file decoder.
@@ -29,7 +30,7 @@ namespace RawSpeed {
 
 Cr2Decoder::Cr2Decoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 4;
+  decoderVersion = 5;
 }
 
 Cr2Decoder::~Cr2Decoder(void) {
@@ -39,6 +40,43 @@ Cr2Decoder::~Cr2Decoder(void) {
 }
 
 RawImage Cr2Decoder::decodeRawInternal() {
+  if(hints.find("old_format") != hints.end()) {
+    TiffEntry *offset = mRootIFD->getEntryRecursive((TiffTag)0x81);
+    if (!offset)
+      ThrowRDE("CR2 Decoder: Couldn't find offset");
+    uint32 off = offset->getInt();
+    ByteStream *b;
+    if (getHostEndianness() == big)
+      b = new ByteStream(mFile->getData(off+41), mFile->getSize());
+    else
+      b = new ByteStreamSwap(mFile->getData(off+41), mFile->getSize());
+    uint32 height = b->getShort()*2;
+    uint32 width = b->getShort();
+
+    // Every two lines are encoded as a single line, probably to try and get
+    // better compression by getting the same RGBG sequence in every line
+    mRaw->dim = iPoint2D(width*2, height/2);
+    mRaw->createData();
+    LJpegPlain l(mFile, mRaw);
+    l.startDecoder(off, mFile->getSize()-off, 0, 0);
+
+    // We now have a double width half height image we need to convert to the
+    // normal format
+    iPoint2D final_size(width, height);
+    RawImage procRaw = RawImage::create(final_size, TYPE_USHORT16, 1);
+    procRaw->clearArea(iRectangle2D(iPoint2D(0,0), procRaw->dim));
+    procRaw->metadata = mRaw->metadata;
+
+    for (uint32 y = 0; y < height; y++) {
+      ushort16 *dst = (ushort16*)procRaw->getData(0,y);
+      ushort16 *src = (ushort16*)mRaw->getData(y%2 == 0 ? 0 : width, y/2);
+      for (uint32 x = 0; x < width; x++)
+        dst[x] = src[x];
+    }
+    mRaw = procRaw;
+
+    return mRaw;
+  }
 
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag((TiffTag)0xc5d8);
 
@@ -153,18 +191,20 @@ void Cr2Decoder::checkSupportInternal(CameraMetaData *meta) {
     ThrowRDE("CR2 Support: Make name not found");
   string make = data[0]->getEntry(MAKE)->getString();
   string model = data[0]->getEntry(MODEL)->getString();
-  data = mRootIFD->getIFDsWithTag((TiffTag)0xc5d8);
 
-  if (data.empty())
-    ThrowRDE("CR2 Decoder: No image data found");
+  if (model != "Canon EOS-1DS" && model != "Canon EOS-1D") {
+    data = mRootIFD->getIFDsWithTag((TiffTag)0xc5d8);
+    if (data.empty())
+      ThrowRDE("CR2 Decoder: No image data found");
 
-  TiffIFD* raw = data[0];
+    TiffIFD* raw = data[0];
 
-  if (raw->hasEntry((TiffTag)0xc6c5)) {
-    ushort16 ss = raw->getEntry((TiffTag)0xc6c5)->getInt();
-    if (ss == 4) {
-      this->checkCameraSupported(meta, make, model, "sRaw1");
-      return;
+    if (raw->hasEntry((TiffTag)0xc6c5)) {
+      ushort16 ss = raw->getEntry((TiffTag)0xc6c5)->getInt();
+      if (ss == 4) {
+        this->checkCameraSupported(meta, make, model, "sRaw1");
+        return;
+      }
     }
   }
   this->checkCameraSupported(meta, make, model, "");
@@ -258,6 +298,15 @@ void Cr2Decoder::decodeMetaDataInternal(CameraMetaData *meta) {
         mRaw->metadata.wbCoeffs[2] = cam_mul[2] / green;
       } else {
         writeLog(DEBUG_PRIO_INFO, "CR2 Decoder: CANONPOWERSHOTG9WB has to be BYTE, %d found.", g9_wb->type);
+      }
+    } else if (mRootIFD->hasEntryRecursive((TiffTag) 0xa4)) {
+      // WB for the old 1D and 1DS
+      TiffEntry *wb = mRootIFD->getEntryRecursive((TiffTag) 0xa4);
+      if (wb->count >= 3) {
+        const ushort16 *tmp = wb->getShortArray();
+        mRaw->metadata.wbCoeffs[0] = (float)tmp[0];
+        mRaw->metadata.wbCoeffs[1] = (float)tmp[1];
+        mRaw->metadata.wbCoeffs[2] = (float)tmp[2];
       }
     }
   }

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -629,6 +629,32 @@
 			<Horizontal y="4" height="44"/>
 		</BlackAreas>
 	</Camera>
+	<Camera make="Canon" model="Canon EOS-1D" decoder_version="5">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3588"/>
+		<Hints>
+			<Hint name="old_format" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="Canon EOS-1DS" decoder_version="5">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3500"/>
+		<Hints>
+			<Hint name="old_format" value=""/>
+		</Hints>
+	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark II">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>


### PR DESCRIPTION
This is the basic skeleton for support for the original Canon D1 and D1s. The code seems to work fine but produce an image that only occupies half the height. Something in the lossless jpeg decoding isn't working properly.

Klaus, any pointers on what to do to fix this? I don't see any special cases for these cameras in the dcraw code. Sample files are at:

http://www.rawsamples.ch/raws/canon/1ds/RAW_CANON_1DS.ZIP
http://www.rawsamples.ch/raws/canon/1d/RAW_CANON_1D_RAW.ZIP

The actual .TIF raw files are inside the ZIPs
