### PR TITLE
Add support for Fuji F700, F900EXR and S200EXR

### DIFF
--- a/RawSpeed/RafDecoder.cpp
+++ b/RawSpeed/RafDecoder.cpp
@@ -89,11 +89,16 @@ RawImage RafDecoder::decodeRawInternal() {
   ByteStream input(mFile->getData(off), mFile->getSize() - off);
   iPoint2D pos(0, 0);
 
-  if (mRootIFD->endian == big)
+  if (hints.find("double_width_unpacked") != hints.end()) {
+    Decode16BitRawUnpacked(input, width*2, height);
+  } else if (mRootIFD->endian == big) {
     Decode16BitRawBEunpacked(input, width, height);
-  else
-    readUncompressedRaw(input, mRaw->dim, pos, width*bps/8, bps, BitOrder_Plain);
-
+  } else {
+    if (hints.find("jpeg32_bitorder") != hints.end())
+      readUncompressedRaw(input, mRaw->dim, pos, width*bps/8, bps, BitOrder_Jpeg32);
+    else
+      readUncompressedRaw(input, mRaw->dim, pos, width*bps/8, bps, BitOrder_Plain);
+  }
   return mRaw;
 }
 

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4358,7 +4358,17 @@
 			<Hint name="fuji_rotate" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="FUJIFILM" model="FinePix F700" supported="no">
+	<Camera make="FUJIFILM" model="FinePix S200EXR">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="28" y="0" width="-28" height="0"/>
+		<Sensor black="519" white="16250"/>
+	</Camera>
+	<Camera make="FUJIFILM" model="FinePix F700">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -4367,7 +4377,18 @@
 		<Sensor black="0" white="16383"/>
 	  <Hints>
 			<Hint name="fuji_rotate" value=""/>
+			<Hint name="double_width_unpacked" value=""/>
 		</Hints>
+	</Camera>
+	<Camera make="FUJIFILM" model="FinePix F900EXR">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-64" height="0"/>
+		<Sensor black="256" white="3900"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix E550">
 		<CFA2 width="2" height="2">
@@ -4518,6 +4539,19 @@
 		<Crop x="64" y="0" width="-64" height="0"/>
 		<Hints>
 			<Hint name="fuji_rotate" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="FUJIFILM" model="FinePix HS10 HS11">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="50" white="3900"/>
+		<Hints>
+			<Hint name="jpeg32_bitorder" value=""/>
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix X100">


### PR DESCRIPTION
Add two new cameras (F900 and S200EXR) and finally fix the F700. Turns out the F700 had a weird problem where the width reported in the file is half of what it should be. Works fine now and fixes issue #40 
