### PR TITLE
Fix a few small issues found by coverity

### DIFF
--- a/RawSpeed/ArwDecoder.cpp
+++ b/RawSpeed/ArwDecoder.cpp
@@ -185,7 +185,7 @@ void ArwDecoder::DecodeARW(ByteStream &input, uint32 w, uint32 h) {
       if (len == 4)
         while (len < 17 && !bits.getBitNoFill()) len++;
       int diff = bits.getBits(len);
-      if ((diff & (1 << (len - 1))) == 0)
+      if (len && (diff & (1 << (len - 1))) == 0)
         diff -= (1 << len) - 1;
       sum += diff;
       _ASSERTE(!(sum >> 12));

--- a/RawSpeed/DcrDecoder.cpp
+++ b/RawSpeed/DcrDecoder.cpp
@@ -136,7 +136,7 @@ void DcrDecoder::decodeKodak65000Segment(ByteStream &input, ushort16 *out, uint3
     uint32 diff = (uint32)bitbuf & (0xffff >> (16-len));
     bitbuf >>= len;
     bits -= len;
-    if ((diff & (1 << (len-1))) == 0)
+    if (len && (diff & (1 << (len-1))) == 0)
       diff -= (1 << len) - 1;
     out[i] = diff;
   }

--- a/RawSpeed/RafDecoder.cpp
+++ b/RawSpeed/RafDecoder.cpp
@@ -27,7 +27,8 @@ namespace RawSpeed {
 
 RafDecoder::RafDecoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
-      decoderVersion = 1;
+  decoderVersion = 1;
+  alt_layout = FALSE;
 }
 RafDecoder::~RafDecoder(void) {
   if (mRootIFD)
@@ -45,7 +46,6 @@ RawImage RafDecoder::decodeRawInternal() {
   mFile = raw->getFileMap();
   uint32 height = 0;
   uint32 width = 0;
-  alt_layout = FALSE;
 
   if (raw->hasEntry(FUJI_RAWIMAGEFULLHEIGHT)) {
     height = raw->getEntry(FUJI_RAWIMAGEFULLHEIGHT)->getInt();

--- a/RawSpeed/TiffEntry.cpp
+++ b/RawSpeed/TiffEntry.cpp
@@ -61,6 +61,7 @@ TiffEntry::TiffEntry(TiffTag _tag, TiffDataType _type, uint32 _count, const ucha
   tag = _tag;
   type = _type;
   count = _count;
+  data_offset = -1; // Set nonsense value in case someone tries to use it
   if (NULL == _data) {
     uint32 bytesize = _count << datashifts[_type];
     own_data = new uchar8[bytesize];
@@ -230,7 +231,7 @@ std::string TiffEntry::getValueAsString()
     }
   }
   string ret(temp_string);
-  delete temp_string;
+  delete [] temp_string;
   return ret;
 }
 

--- a/RawSpeed/TiffIFD.cpp
+++ b/RawSpeed/TiffIFD.cpp
@@ -202,7 +202,12 @@ TiffIFD* TiffIFD::parseMakerNote(FileMap *f, uint32 offset, Endianness parent_en
       ThrowTPE("Cannot determine Pentax makernote endianness");
     data +=10;
     offset = 10;
+  // Check for fuji signature in else block so we don't accidentally leak FileMap
+  } else if (0 == memcmp(fuji_signature,&data[0], sizeof(fuji_signature))) {
+    mFile = new FileMap(f->getDataWrt(offset), f->getSize()-offset);
+    offset = 12;
   }
+
   // Panasonic has the word Exif at byte 6, a complete Tiff header starts at byte 12
   // This TIFF is 0 offset based
   if (data[6] == 0x45 && data[7] == 0x78 && data[8] == 0x69 && data[9] == 0x66)
@@ -212,13 +217,6 @@ TiffIFD* TiffIFD::parseMakerNote(FileMap *f, uint32 offset, Endianness parent_en
       ThrowTPE("Cannot determine Panasonic makernote endianness");
     data +=20;
     offset +=20;
-  }
-
-  // Check for fuji signature
-
-  if (0 == memcmp(fuji_signature,&data[0], sizeof(fuji_signature))) {
-    mFile = new FileMap(f->getDataWrt(offset), f->getSize()-offset);
-    offset = 12;
   }
 
   // Some have MM or II to indicate endianness - read that


### PR DESCRIPTION
A few small but real bugs found by the coverity scan that darktable does. This fixes almost everything there, except bug #35 and a few issues in the X3fDecoder that I didn't want to mess with since I don't have any working files to test it against.
