### PR TITLE
Fix a typo in the NefDecoder

### DIFF
--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -344,7 +344,7 @@ string NefDecoder::getMode() {
   if (1 == compression)
     mode << bitPerPixel << "bit-uncompressed";
   else
-    mode << bitPerPixel << "bit-uncompressed";
+    mode << bitPerPixel << "bit-compressed";
   return mode.str();
 }
 


### PR DESCRIPTION
The mode string creation was wrong, always returning uncompressed.
