### PR TITLE
Expose the needed metadata for fuji rotation and scaling of non-square pixel cameras

### DIFF
--- a/RawSpeed/RafDecoder.cpp
+++ b/RawSpeed/RafDecoder.cpp
@@ -161,14 +161,21 @@ void RafDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   if (rotate && !this->uncorrectedRawValues) {
     // Calculate the 45 degree rotated size;
     uint32 rotatedsize;
-    if (alt_layout)
+    uint32 rotationPos;
+    if (alt_layout) {
       rotatedsize = new_size.y+new_size.x/2;
-    else
+      rotationPos = new_size.x/2 - 1;
+    }
+    else {
       rotatedsize = new_size.x+new_size.y/2;
+      rotationPos = new_size.x - 1;
+    }
 
-    iPoint2D final_size(rotatedsize, rotatedsize);
+    iPoint2D final_size(rotatedsize, rotatedsize-1);
     RawImage rotated = RawImage::create(final_size, TYPE_USHORT16, 1);
     rotated->clearArea(iRectangle2D(iPoint2D(0,0), rotated->dim));
+    rotated->fujiRotationPos = rotationPos;
+
     int dest_pitch = (int)rotated->pitch / 2;
     ushort16 *dst = (ushort16*)rotated->getData(0,0);
 

--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -569,6 +569,10 @@ RawSpeed::RawImage RawDecoder::decodeRaw()
 {
   try {
     RawImage raw = decodeRawInternal();
+    if(hints.find("pixel_aspect_ratio") != hints.end()) {
+      stringstream convert(hints.find("pixel_aspect_ratio")->second);
+      convert >> raw->pixelAspectRatio;
+    }
     if (interpolateBadPixels)
       raw->fixBadPixels();
     return raw;

--- a/RawSpeed/RawImage.cpp
+++ b/RawSpeed/RawImage.cpp
@@ -41,7 +41,8 @@ RawImageData::RawImageData(void):
   pthread_mutex_init(&errMutex, NULL);
   pthread_mutex_init(&mBadPixelMutex, NULL);
   mDitherScale = TRUE;
-  fujiWidth = 0;
+  fujiRotationPos = 0;
+  pixelAspectRatio = 1;
 }
 
 RawImageData::RawImageData(iPoint2D _dim, uint32 _bpc, uint32 _cpp) :
@@ -54,7 +55,8 @@ RawImageData::RawImageData(iPoint2D _dim, uint32 _bpc, uint32 _cpp) :
   isoSpeed = 0;
   mBadPixelMap = NULL;
   mDitherScale = TRUE;
-  fujiWidth = 0;
+  fujiRotationPos = 0;
+  pixelAspectRatio = 1;
   createData();
   pthread_mutex_init(&mymutex, NULL);
   pthread_mutex_init(&errMutex, NULL);

--- a/RawSpeed/RawImage.h
+++ b/RawSpeed/RawImage.h
@@ -97,7 +97,15 @@ public:
   uchar8 *mBadPixelMap;
   uint32 mBadPixelMapPitch;
   bool mDitherScale;           // Should upscaling be done with dither to minimize banding?
-  uint32 fujiWidth;            // Similar to dcraw.
+
+  // How many pixels far down the left edge and far up the right edge the image 
+  // corners are when the image is rotated 45 degrees in Fuji rotated sensors.
+  uint32 fujiRotationPos;
+
+  // Aspect ratio of the pixels, usually 1 but some cameras need scaling
+  // <1 means the image needs to be stretched vertically, (0.5 means 2x)
+  // >1 means the image needs to be stretched horizontally (2 mean 2x)
+  double pixelAspectRatio;
 
 protected:
   RawImageType dataType;

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -950,7 +950,7 @@
 		<Crop x="0" y="0" width="2012" height="1324"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1X" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D1X">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -959,6 +959,9 @@
 		</CFA>
 		<Crop x="0" y="0" width="4024" height="1324"/>
 		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="pixel_aspect_ratio" value="0.5"/>
+		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D200">
 		<CFA width="2" height="2">


### PR DESCRIPTION
This exposes the needed metadata to do the post-demosaic rotation and scaling needed to support cameras like the old Fuji's and the Nikon D1X.
