### PR TITLE
Add subpixel dithering to curve lookups.

### DIFF
--- a/RawSpeed/ArwDecoder.cpp
+++ b/RawSpeed/ArwDecoder.cpp
@@ -118,6 +118,7 @@ RawImage ArwDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
 
+  ushort16 curve[0x4001];
   const ushort16* c = raw->getEntry(SONY_CURVE)->getShortArray();
   uint32 sony_curve[] = { 0, 0, 0, 0, 0, 4095 };
 
@@ -130,6 +131,9 @@ RawImage ArwDecoder::decodeRawInternal() {
   for (uint32 i = 0; i < 5; i++)
     for (uint32 j = sony_curve[i] + 1; j <= sony_curve[i+1]; j++)
       curve[j] = curve[j-1] + (1 << i);
+
+  if (!uncorrectedRawValues)
+    mRaw->setTable(curve, 0x4000, true);
 
   uint32 c2 = counts->getInt();
   uint32 off = offsets->getInt();
@@ -151,6 +155,13 @@ RawImage ArwDecoder::decodeRawInternal() {
   } catch (IOException &e) {
     mRaw->setError(e.what());
     // Let's ignore it, it may have delivered somewhat useful data.
+  }
+
+  // Set the table, if it should be needed later.
+  if (uncorrectedRawValues) {
+    mRaw->setTable(curve, 0x4000, false);
+  } else {
+    mRaw->setTable(NULL);
   }
 
   return mRaw;
@@ -292,10 +303,7 @@ void ArwDecoder::decodeThreaded(RawDecoderThread * t) {
           if (p > 0x7ff)
             p = 0x7ff;
         }
-        if (uncorrectedRawValues)
-          dest[x+i*2] = p;
-        else
-          dest[x+i*2] = curve[p << 1];
+        mRaw->setWithLookUp(p << 1, (uchar8*)&dest[x+i*2]);
       }
       x += x & 1 ? 31 : 1;  // Skip to next 32 pixels
     }

--- a/RawSpeed/ArwDecoder.h
+++ b/RawSpeed/ArwDecoder.h
@@ -46,7 +46,6 @@ protected:
   void DecodeARW2(ByteStream &input, uint32 w, uint32 h, uint32 bpp);
   void DecodeSR2(TiffIFD* raw);
   TiffIFD *mRootIFD;
-  uint32 curve[0x4001];
   ByteStream *in;
   int mShiftDownScale;
 };

--- a/RawSpeed/DngDecoder.cpp
+++ b/RawSpeed/DngDecoder.cpp
@@ -401,22 +401,23 @@ RawImage DngDecoder::decodeRawInternal() {
   }
 
   // Linearization
-  if (raw->hasEntry(LINEARIZATIONTABLE) && !uncorrectedRawValues) {
+  if (raw->hasEntry(LINEARIZATIONTABLE)) {
     const ushort16* intable = raw->getEntry(LINEARIZATIONTABLE)->getShortArray();
     uint32 len =  raw->getEntry(LINEARIZATIONTABLE)->count;
-    ushort16 table[65536];
-    for (uint32 i = 0; i < 65536 ; i++) {
-      if (i < len)
-        table[i] = intable[i];
-      else
-        table[i] = intable[len-1];
+    mRaw->setTable(intable, len, true);
+    if (!uncorrectedRawValues) {
+      mRaw->sixteenBitLookup();
     }
-    for (int y = 0; y < mRaw->dim.y; y++) {
+
+    if (0) {
+      // Test average for bias
       uint32 cw = mRaw->dim.x * mRaw->getCpp();
-      ushort16* pixels = (ushort16*)mRaw->getData(0, y);
+      ushort16* pixels = (ushort16*)mRaw->getData(0, 500);
+      float avg = 0.0f;
       for (uint32 x = 0; x < cw; x++) {
-        pixels[x]  = table[pixels[x]];
+        avg += (float)pixels[x];
       }
+      printf("Average:%f\n", avg/(float)cw);    
     }
   }
 

--- a/RawSpeed/DngDecoder.cpp
+++ b/RawSpeed/DngDecoder.cpp
@@ -404,9 +404,10 @@ RawImage DngDecoder::decodeRawInternal() {
   if (raw->hasEntry(LINEARIZATIONTABLE)) {
     const ushort16* intable = raw->getEntry(LINEARIZATIONTABLE)->getShortArray();
     uint32 len =  raw->getEntry(LINEARIZATIONTABLE)->count;
-    mRaw->setTable(intable, len, true);
+    mRaw->setTable(intable, len, !uncorrectedRawValues);
     if (!uncorrectedRawValues) {
       mRaw->sixteenBitLookup();
+      mRaw->setTable(NULL);
     }
 
     if (0) {

--- a/RawSpeed/NikonDecompressor.cpp
+++ b/RawSpeed/NikonDecompressor.cpp
@@ -75,7 +75,7 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
   uint32 csize = metadata->getShort();
   if (csize  > 1)
     step = _max / (csize - 1);
-  if (v0 == 68 && v1 == 32 && step > 0 && !uncorrectedRawValues) {
+  if (v0 == 68 && v1 == 32 && step > 0) {
     for (uint32 i = 0; i < csize; i++)
       curve[i*step] = metadata->getShort();
     for (int i = 0; i < _max; i++)
@@ -83,7 +83,7 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
                   curve[i-i%step+step] * (i % step)) / step;
     metadata->setAbsoluteOffset(562);
     split = metadata->getShort();
-  } else if (v0 != 70 && csize <= 0x4001 && !uncorrectedRawValues) {
+  } else if (v0 != 70 && csize <= 0x4001) {
     for (uint32 i = 0; i < csize; i++) {
       curve[i] = metadata->getShort();
     }
@@ -126,7 +126,13 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
       mRaw->setWithLookUp(clampbits(pLeft2,15), (uchar8*)dest++);
     }
   }
-  mRaw->setTable(NULL);
+
+  if (uncorrectedRawValues) {
+    mRaw->setTable(curve, _max, false);
+  } else {
+    mRaw->setTable(NULL);
+  }
+
 }
 
 /*

--- a/RawSpeed/NikonDecompressor.h
+++ b/RawSpeed/NikonDecompressor.h
@@ -39,7 +39,7 @@ public:
 private:
   void initTable(uint32 huffSelect);
   int HuffDecodeNikon(BitPumpMSB& bits);
-  ushort16 curve[0x8000];
+  ushort16 curve[65536];
 };
 
 static const uchar8 nikon_tree[][32] = {

--- a/RawSpeed/RawImage.cpp
+++ b/RawSpeed/RawImage.cpp
@@ -32,7 +32,7 @@ RawImageData::RawImageData(void):
     dim(0, 0), isCFA(true), cfa(iPoint2D(0,0)),
     blackLevel(-1), whitePoint(65536),
     dataRefCount(0), data(0), cpp(1), bpp(0),
-    uncropped_dim(0, 0) {
+    uncropped_dim(0, 0), table(NULL) {
   blackLevelSeparate[0] = blackLevelSeparate[1] = blackLevelSeparate[2] = blackLevelSeparate[3] = -1;
   pthread_mutex_init(&mymutex, NULL);
   subsampling.x = subsampling.y = 1;
@@ -49,7 +49,7 @@ RawImageData::RawImageData(iPoint2D _dim, uint32 _bpc, uint32 _cpp) :
     dim(_dim), isCFA(_cpp==1), cfa(iPoint2D(0,0)),
     blackLevel(-1), whitePoint(65536),
     dataRefCount(0), data(0), cpp(_cpp), bpp(_bpc * _cpp),
-    uncropped_dim(0, 0) {
+    uncropped_dim(0, 0), table(NULL) {
   blackLevelSeparate[0] = blackLevelSeparate[1] = blackLevelSeparate[2] = blackLevelSeparate[3] = -1;
   subsampling.x = subsampling.y = 1;
   isoSpeed = 0;
@@ -71,6 +71,9 @@ RawImageData::~RawImageData(void) {
   pthread_mutex_destroy(&mBadPixelMutex);
   for (uint32 i = 0 ; i < errors.size(); i++) {
     free((void*)errors[i]);
+  }
+  if (table != NULL) {
+    delete table;
   }
   errors.clear();
   destroyData();
@@ -467,6 +470,9 @@ void RawImageWorker::performTask()
     case FIX_BAD_PIXELS:
       data->fixBadPixelsThread(start_y, end_y);
       break;
+    case APPLY_LOOKUP:
+      data->doLookup(start_y, end_y);
+      break;
     default:
       _ASSERTE(false);
     }
@@ -479,6 +485,84 @@ void RawImageWorker::performTask()
   }
 }
 
+void RawImageData::sixteenBitLookup()
+{
+  if (table == NULL) {
+    return;
+  }
+  startWorker(RawImageWorker::APPLY_LOOKUP, true);
+}
+
+void RawImageData::setTable( TableLookUp *t )
+{
+  if (table != NULL) {
+    delete table;
+  }
+  table = t;
+}
+
+void RawImageData::setTable(ushort16 table[65536], int nfilled, bool dither) {
+  TableLookUp* t = new TableLookUp(1, dither);
+  t->setTable(0, table, nfilled);
+  this->setTable(t);
+}
+
+const int TABLE_SIZE = 65536 * 2;
+
+// Creates n numre of tables.
+TableLookUp::TableLookUp( int _ntables, bool _dither ) : ntables(_ntables), dither(_dither) {
+  tables = NULL;
+  if (ntables < 1) {
+    ThrowRDE("Cannot construct 0 tables");
+  }
+  tables = new ushort16[ntables * TABLE_SIZE];
+  random = 0x49f6428a;
+  memset(tables, sizeof(ushort16) * ntables * TABLE_SIZE, 0);
+}
+
+TableLookUp::~TableLookUp()
+{
+  if (tables != NULL) {
+    delete[] tables;
+    tables = NULL;
+  }
+}
+
+
+void TableLookUp::setTable( int ntable, ushort16 table[65536] , int nfilled) {
+  if (ntable > ntables) {
+    ThrowRDE("Table lookup with number greater than number of tables.");
+  }
+  ushort16* t = &tables[ntable* TABLE_SIZE];
+  if (!dither) {
+    for (int i = 0; i < 65536; i++) {
+      t[i] = (i < nfilled) ? table[i] : table[nfilled-1];
+    }
+    return;
+  }
+  for (int i = 0; i < nfilled; i++) {
+    int lower = i > 0 ? table[i-1] : table[0];
+    int upper = i < (nfilled-1) ? table[i+1] : table[nfilled-1];
+    int delta = upper - lower;
+    t[i*2] = lower;
+    t[i*2+1] = delta;
+  }
+
+  for (int i = nfilled; i < 65536; i++) {
+    t[i*2] = table[nfilled-1];
+    t[i*2+1] = 0;
+  }
+  t[0] = t[1];
+  t[TABLE_SIZE - 1] = t[TABLE_SIZE - 2];
+}
+
+
+ushort16* TableLookUp::getTable(int n) {
+  if (n > ntables) {
+    ThrowRDE("Table lookup with number greater than number of tables.");
+  }
+  return &tables[n * TABLE_SIZE];
+}
 
 
 } // namespace RawSpeed

--- a/RawSpeed/RawImage.cpp
+++ b/RawSpeed/RawImage.cpp
@@ -548,7 +548,7 @@ void TableLookUp::setTable(int ntable, const ushort16 *table , int nfilled) {
     int lower = i > 0 ? table[i-1] : center;
     int upper = i < (nfilled-1) ? table[i+1] : center;
     int delta = upper - lower;
-    t[i*2] = center - ((upper - lower) / 4);
+    t[i*2] = center - ((upper - lower + 2) / 4);
     t[i*2+1] = delta;
   }
 

--- a/RawSpeed/RawImage.h
+++ b/RawSpeed/RawImage.h
@@ -34,7 +34,9 @@ typedef enum {TYPE_USHORT16, TYPE_FLOAT32} RawImageType;
 
 class RawImageWorker {
 public:
-  typedef enum {SCALE_VALUES, FIX_BAD_PIXELS, APPLY_LOOKUP} RawImageWorkerTask;
+  typedef enum {
+    SCALE_VALUES = 1, FIX_BAD_PIXELS = 2, APPLY_LOOKUP = 3 | 0x1000, FULL_IMAGE = 0x1000
+  } RawImageWorkerTask;
   RawImageWorker(RawImageData *img, RawImageWorkerTask task, int start_y, int end_y);
   void startThread();
   void waitForThread();
@@ -51,7 +53,7 @@ class TableLookUp {
 public:
   TableLookUp(int ntables, bool dither);
   ~TableLookUp();
-  void setTable( int ntable, ushort16 table[65536], int nfilled);
+  void setTable(int ntable, const ushort16* table, int nfilled);
   ushort16* getTable(int n);
   const int ntables;
   uint32 random;
@@ -85,7 +87,7 @@ public:
   virtual void transferBadPixelsToMap();
   virtual void fixBadPixels();
   void expandBorder(iRectangle2D validData);
-  void setTable(ushort16 table[65536], int nfilled, bool dither);
+  void setTable(const ushort16* table, int nfilled, bool dither);
   void setTable(TableLookUp *t);
 
   bool isAllocated() {return !!data;}

--- a/RawSpeed/RawImageDataFloat.cpp
+++ b/RawSpeed/RawImageDataFloat.cpp
@@ -362,4 +362,20 @@ void RawImageDataFloat::fixBadPixel( uint32 x, uint32 y, int component )
 
 }
 
+
+void RawImageDataFloat::doLookup( int start_y, int end_y ) {
+  ThrowRDE("Float point lookup tables not implemented");
+}
+
+void RawImageDataFloat::setWithLookUp(ushort16 value, uchar8* dst ) {
+  float* dest = (float*)dst;
+  if (table == NULL) {
+    *dest = (float)value * (1.0f/65535);
+    return;
+  }
+
+  ThrowRDE("Float point lookup tables not implemented");
+}
+
+
 } // namespace RawSpeed

--- a/RawSpeed/RawImageDataU16.cpp
+++ b/RawSpeed/RawImageDataU16.cpp
@@ -441,23 +441,24 @@ void RawImageDataU16::fixBadPixel( uint32 x, uint32 y, int component )
       fixBadPixel(x,y,i);
 }
 
+// TODO: Could be done with SSE2
 void RawImageDataU16::doLookup( int start_y, int end_y )
 {
   if (table->ntables == 1) {
     ushort16* t = table->getTable(0);
     if (table->dither) {
-      int gw = dim.x * cpp;
+      int gw = uncropped_dim.x * cpp;
       uint32* t = (uint32*)table->getTable(0);
       for (int y = start_y; y < end_y; y++) {
-        uint32 v = dim.x + y * 36959;
-        ushort16 *pixel = (ushort16*)getData(0, y);
+        uint32 v = (uncropped_dim.x + y * 13) ^ 0x45694584;
+        ushort16 *pixel = (ushort16*)getDataUncropped(0, y);
         for (int x = 0 ; x < gw; x++) {
           ushort16 p = *pixel;
           uint32 lookup = t[p];
           uint32 base = lookup & 0xffff;
           uint32 delta = lookup >> 16;
           v = 15700 *(v & 65535) + (v >> 16);
-          uint32 pix = base + ((delta * v&2047) >> 11);
+          uint32 pix = base + ((delta * (v&2047)) >> 12);
           *pixel = pix;
           pixel++;
         }
@@ -465,9 +466,9 @@ void RawImageDataU16::doLookup( int start_y, int end_y )
       return;
     }
 
-    int gw = dim.x * cpp;
+    int gw = uncropped_dim.x * cpp;
     for (int y = start_y; y < end_y; y++) {
-      ushort16 *pixel = (ushort16*)getData(0, y);
+      ushort16 *pixel = (ushort16*)getDataUncropped(0, y);
       for (int x = 0 ; x < gw; x++) {
         *pixel = t[*pixel];
         pixel ++;
@@ -493,7 +494,7 @@ void RawImageDataU16::setWithLookUp(ushort16 value, uchar8* dst) {
     uint32 delta = lookup >> 16;
     
     table->random = 15700 *(table->random & 65535) + (table->random >> 16);
-    uint32 pix = base + ((delta * table->random&2047) >> 11);
+    uint32 pix = base + ((delta * table->random&2047) >> 12);
     *dest = pix;
     return;
   }

--- a/RawSpeed/RawImageDataU16.cpp
+++ b/RawSpeed/RawImageDataU16.cpp
@@ -458,7 +458,7 @@ void RawImageDataU16::doLookup( int start_y, int end_y )
           uint32 base = lookup & 0xffff;
           uint32 delta = lookup >> 16;
           v = 15700 *(v & 65535) + (v >> 16);
-          uint32 pix = base + ((delta * (v&2047)) >> 12);
+          uint32 pix = base + (((delta * (v&2047) + 1024)) >> 12);
           *pixel = pix;
           pixel++;
         }
@@ -494,7 +494,7 @@ void RawImageDataU16::setWithLookUp(ushort16 value, uchar8* dst) {
     uint32 delta = lookup >> 16;
     
     table->random = 15700 *(table->random & 65535) + (table->random >> 16);
-    uint32 pix = base + ((delta * table->random&2047) >> 12);
+    uint32 pix = base + ((delta * (table->random&2047) + 1024) >> 12);
     *dest = pix;
     return;
   }


### PR DESCRIPTION
This will add subpixel dithering when applying curve upscaling on DNG/ARW/NEF images that have had a curve compression applied.

Basicly, if a curve is specified as:

```
0 -> 0
1 -> 3
2 -> 6
3 -> 10
4 -> 15
```

If an input value of 2 is encounted, it will look at the surrounding values and select one within half of the distance between them:

```
d = 10 - 3
out = 6 + random(0...1) * (d / 2) - (d / 4)
```

This means that out will be between 4.25 and 7.75
