### PR TITLE
Support for the crazy Nikon subformats in the D800, D810 and D4s

### DIFF
--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -373,11 +373,16 @@ void NefDecoder::DecodeRGBUncompressed() {
 void NefDecoder::checkSupportInternal(CameraMetaData *meta) {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
   if (data.empty())
-    ThrowRDE("NEF Support check: Model name found");
+    ThrowRDE("NEF Support check: Model name not found");
   string make = data[0]->getEntry(MAKE)->getString();
   string model = data[0]->getEntry(MODEL)->getString();
+
   string mode = getMode();
-  if (meta->hasCamera(make, model, mode))
+  string extended_mode = getExtendedMode(mode);
+
+  if (meta->hasCamera(make, model, extended_mode))
+    this->checkCameraSupported(meta, make, model, extended_mode);
+  else if (meta->hasCamera(make, model, mode))
     this->checkCameraSupported(meta, make, model, mode);
   else
     this->checkCameraSupported(meta, make, model, "");
@@ -401,6 +406,21 @@ string NefDecoder::getMode() {
   return mode.str();
 }
 
+string NefDecoder::getExtendedMode(string mode) {
+  ostringstream extended_mode;
+
+  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(CFAPATTERN);
+  if (data.empty())
+    ThrowRDE("NEF Support check: Image size not found");
+  if (!data[0]->hasEntry(IMAGEWIDTH) || !data[0]->hasEntry(IMAGELENGTH))
+    ThrowRDE("NEF Support: Image size not found");
+  uint32 width = data[0]->getEntry(IMAGEWIDTH)->getInt();
+  uint32 height = data[0]->getEntry(IMAGELENGTH)->getInt();
+
+  extended_mode << width << "x" << height << "-" << mode;
+  return extended_mode.str();
+}
+
 void NefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
   mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN2, CFA_BLUE);
@@ -408,7 +428,7 @@ void NefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
 
   if (data.empty())
-    ThrowRDE("NEF Meta Decoder: Model name found");
+    ThrowRDE("NEF Meta Decoder: Model name not found");
   if (!data[0]->hasEntry(MAKE))
     ThrowRDE("NEF Support: Make name not found");
 
@@ -422,7 +442,10 @@ void NefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
     iso = mRootIFD->getEntryRecursive(ISOSPEEDRATINGS)->getInt();
 
   string mode = getMode();
-  if (meta->hasCamera(make, model, mode)) {
+  string extended_mode = getExtendedMode(mode);
+  if (meta->hasCamera(make, model, extended_mode)) {
+    setMetaData(meta, make, model, extended_mode, iso);
+  } else if (meta->hasCamera(make, model, mode)) {
     setMetaData(meta, make, model, mode, iso);
   } else {
     setMetaData(meta, make, model, "", iso);

--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -363,6 +363,7 @@ void NefDecoder::DecodeRGBUncompressed() {
   mRaw->dim = iPoint2D(width, height);
   mRaw->setCpp(3);
   mRaw->isCFA = false;
+  mRaw->preAppliedWB = true;
   mRaw->createData();
 
   ByteStream in(mFile->getData(offset), mFile->getSize()-offset);

--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -212,7 +212,7 @@ void NefDecoder::DecodeUncompressed() {
     else
       slice.h = yPerSlice;
 
-    offY += yPerSlice;
+    offY = MIN(height, offY + yPerSlice);
 
     if (mFile->isValid(slice.offset + slice.count)) // Only decode if size is valid
       slices.push_back(slice);

--- a/RawSpeed/NefDecoder.h
+++ b/RawSpeed/NefDecoder.h
@@ -44,8 +44,11 @@ public:
   virtual TiffIFD* getRootIFD() {return mRootIFD;}
 private:
   bool D100IsCompressed(uint32 offset);
+  bool NEFIsUncompressed(TiffIFD *raw);
+  bool NEFIsUncompressedRGB(TiffIFD *raw);
   void DecodeUncompressed();
   void DecodeD100Uncompressed();
+  void DecodeRGBUncompressed();
   void readCoolpixMangledRaw(ByteStream &input, iPoint2D& size, iPoint2D& offset, int inputPitch);
   void readCoolpixSplitRaw(ByteStream &input, iPoint2D& size, iPoint2D& offset, int inputPitch);
   TiffIFD* FindBestImage(vector<TiffIFD*>* data);

--- a/RawSpeed/NefDecoder.h
+++ b/RawSpeed/NefDecoder.h
@@ -53,6 +53,7 @@ private:
   void readCoolpixSplitRaw(ByteStream &input, iPoint2D& size, iPoint2D& offset, int inputPitch);
   TiffIFD* FindBestImage(vector<TiffIFD*>* data);
   string getMode();
+  string getExtendedMode(string mode);
 };
 
 class NefSlice {

--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -185,6 +185,45 @@ void RawDecoder::readUncompressedRaw(ByteStream &input, iPoint2D& size, iPoint2D
   }
 }
 
+void RawDecoder::Decode8BitRGB(ByteStream &input, uint32 w, uint32 h) {
+  uchar8* data = mRaw->getData();
+  uint32 pitch = mRaw->pitch;
+  const uchar8 *in = input.getData();
+  if (input.getRemainSize() < (w*h*3)) {
+    if ((uint32)input.getRemainSize() > w*3) {
+      h = input.getRemainSize() / w*3 - 1;
+      mRaw->setError("Image truncated (file is too short)");
+    } else
+      ThrowIOE("Decode8BitRGB: Not enough data to decode a single line. Image file truncated.");
+  }
+  for (uint32 y = 0; y < h; y++) {
+    ushort16* dest = (ushort16*) & data[y*pitch];
+    for (uint32 x = 0 ; x < w*3; x += 6) {
+      /* Decoding method and coefficients taken from
+         http://www.rawdigger.com/howtouse/nikon-small-raw-internals */
+
+      uint32 g1 = *in++;
+      uint32 g2 = *in++;
+      uint32 g3 = *in++;
+      uint32 g4 = *in++;
+      uint32 g5 = *in++;
+      uint32 g6 = *in++;
+
+      float y1 = g1 | ((g2 & 0x0f) << 8);
+      float y2 = (g2 >> 4) | (g3 << 4);
+      float cb = g4 | ((g5 & 0x0f) << 8);
+      float cr = (g5 >> 4) | (g6 << 4);
+
+      dest[x]   = y1 + 1.40200 * (cr - 2048);
+      dest[x+1] = y1 - 0.34414 * (cb - 2048) - 0.71414 * (cr - 2048);
+      dest[x+2] = y1 + 1.77200 * (cb - 2048);
+      dest[x+3] = y2 + 1.40200 * (cr - 2048);
+      dest[x+4] = y2 - 0.34414 * (cb - 2048) - 0.71414 * (cr - 2048);
+      dest[x+5] = y2 + 1.77200 * (cb - 2048);
+    }
+  }
+}
+
 void RawDecoder::Decode12BitRaw(ByteStream &input, uint32 w, uint32 h) {
   uchar8* data = mRaw->getData();
   uint32 pitch = mRaw->pitch;

--- a/RawSpeed/RawDecoder.h
+++ b/RawSpeed/RawDecoder.h
@@ -165,6 +165,9 @@ protected:
   /* order: Order of the bits - see Common.h for possibilities. */
   void readUncompressedRaw(ByteStream &input, iPoint2D& size, iPoint2D& offset, int inputPitch, int bitPerPixel, BitOrder order);
 
+  /* Read 8bit RGB data */
+  void Decode8BitRGB(ByteStream &input, uint32 w, uint32 h);
+
   /* Faster version for unpacking 12 bit LSB data */
   void Decode12BitRaw(ByteStream &input, uint32 w, uint32 h);
 

--- a/RawSpeed/RawImage.cpp
+++ b/RawSpeed/RawImage.cpp
@@ -43,6 +43,7 @@ RawImageData::RawImageData(void):
   mDitherScale = TRUE;
   fujiRotationPos = 0;
   pixelAspectRatio = 1;
+  preAppliedWB = FALSE;
 }
 
 RawImageData::RawImageData(iPoint2D _dim, uint32 _bpc, uint32 _cpp) :
@@ -57,6 +58,7 @@ RawImageData::RawImageData(iPoint2D _dim, uint32 _bpc, uint32 _cpp) :
   mDitherScale = TRUE;
   fujiRotationPos = 0;
   pixelAspectRatio = 1;
+  preAppliedWB = FALSE;
   createData();
   pthread_mutex_init(&mymutex, NULL);
   pthread_mutex_init(&errMutex, NULL);

--- a/RawSpeed/RawImage.h
+++ b/RawSpeed/RawImage.h
@@ -107,6 +107,9 @@ public:
   // >1 means the image needs to be stretched horizontally (2 mean 2x)
   double pixelAspectRatio;
 
+  // If the image already has WB corrected (used for Nikon sNEF files)
+  bool preAppliedWB;
+
 protected:
   RawImageType dataType;
   RawImageData(void);

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1295,6 +1295,19 @@
 		<Crop x="0" y="0" width="3900" height="2611"/>
 		<Sensor black="0" white="3880"/>
 	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D800" mode="14bit-uncompressed">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="2" y="0" width="-48" height="0"/>
+		<Sensor black="0" white="15520"/>
+		<Aliases>
+			<Alias>NIKON D800E</Alias>
+		</Aliases>
+	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D800">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -1307,6 +1320,67 @@
 		<Aliases>
 			<Alias>NIKON D800E</Alias>
 		</Aliases>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="rgb-uncompressed">
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="nikon_override_auto_black" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="12bit-uncompressed">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="150" white="3880"/>
+		<Hints>
+			<Hint name="msb_override" value=""/>
+			<Hint name="nikon_override_auto_black" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="12bit-compressed">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="150" white="3880"/>
+		<Hints>
+			<Hint name="nikon_override_auto_black" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="14bit-uncompressed">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="600" white="15520"/>
+		<Hints>
+			<Hint name="msb_override" value=""/>
+      <Hint name="nikon_override_auto_black" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="14bit-compressed">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="600" white="15520"/>
+		<Hints>
+			<Hint name="nikon_override_auto_black" value=""/>
+		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D90">
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1295,7 +1295,7 @@
 		<Crop x="0" y="0" width="3900" height="2611"/>
 		<Sensor black="0" white="3880"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D800" mode="14bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D800" mode="7424x4924-14bit-uncompressed">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1303,6 +1303,19 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-48" height="0"/>
+		<Sensor black="0" white="15520"/>
+		<Aliases>
+			<Alias>NIKON D800E</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D800" mode="14bit-uncompressed">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15520"/>
 		<Aliases>
 			<Alias>NIKON D800E</Alias>


### PR DESCRIPTION
This adds support for a couple of quirky formats in the D800 and D810:
- D800 now has the correct whitepoint on 14bit uncompressed images (it was clipping before)
- sNEF (similar to Canon sRAW) giving a RGB image. Here I added a new flag to RawImage to specify that the image already has WB applied
- D810 14bit uncompressed images just needed a hint in cameras.xml
- D810 12bit uncompressed images are now properly detected. Annoyingly there seems to be a bug in the firmware and these are being reported as compressed images. The fix is reasonably sane, just check that the image size is reported as width_height_12bit, instead of relying on the Compression field 
- D800 cropped images are now properly detected by specifying the resolution in the mode, so that we can apply crops only to full-frame images and not to images that have already been cropped and thus have no garbage data in the borders
- All the modes of the D4s, which seems pretty similar to the D810

I also fixed a bug in the uncompressed handling where if the last slice was incomplete (because nslices*yPerSlice > height) we would still allocate space for the full slice even though we decoded partially. This resulted in black rows at the bottom of the image.
