### PR TITLE
Add support for the Samsung NX1

### DIFF
--- a/RawSpeed/SrwDecoder.cpp
+++ b/RawSpeed/SrwDecoder.cpp
@@ -10,6 +10,7 @@
     RawSpeed - RAW file decoder.
 
     Copyright (C) 2009-2010 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -56,7 +57,7 @@ RawImage SrwDecoder::decodeRawInternal() {
   int compression = raw->getEntry(COMPRESSION)->getInt();
   int bits = raw->getEntry(BITSPERSAMPLE)->getInt();
 
-  if (32769 != compression && 32770 != compression && 32772 != compression)
+  if (32769 != compression && 32770 != compression && 32772 != compression && 32773 != compression)
     ThrowRDE("Srw Decoder: Unsupported compression");
 
   if (32769 == compression)
@@ -102,6 +103,15 @@ RawImage SrwDecoder::decodeRawInternal() {
     }
     return mRaw;
   }
+  if (32773 == compression)
+  {
+    try {
+      decodeCompressed3(raw);
+    } catch (RawDecoderException& e) {
+      mRaw->setError(e.what());
+    }
+    return mRaw;
+  }
   ThrowRDE("Srw Decoder: Unsupported compression");
   return mRaw;
 }
@@ -137,7 +147,7 @@ void SrwDecoder::decodeCompressed( TiffIFD* raw )
     ushort16* img_up2 = (ushort16*)mRaw->getData(0, max(0, (int)y - 2));
     // Image is arranged in groups of 16 pixels horizontally
     for (uint32 x = 0; x < width; x += 16) {
-			bits.fill();
+      bits.fill();
       bool dir = !!bits.getBitNoFill();
       for (int i = 0; i < 4; i++)
         op[i] = bits.getBitsNoFill(2);
@@ -224,7 +234,7 @@ void SrwDecoder::decodeCompressed2( TiffIFD* raw, int bits)
   // encode, the second the number of bits that come after with the difference
   // The table has 14 entries because the difference can have between 0 (no 
   // difference) and 13 bits (differences between 12 bits numbers can need 13)
-  const uchar8 tab[14][2] = {{3,4}, {3,7}, {2,6}, {2,5}, {4,3}, {6,0}, {7,9},
+  const ushort16 tab[14][2] = {{3,4}, {3,7}, {2,6}, {2,5}, {4,3}, {6,0}, {7,9},
                                {8,10}, {9,11}, {10,12}, {10,13}, {5,1}, {4,8}, {4,2}};
   encTableItem tbl[1024];
   ushort16 vpred[2][2] = {{0,0},{0,0}}, hpred[2];
@@ -274,6 +284,140 @@ int32 SrwDecoder::samsungDiff (BitPumpMSB &pump, encTableItem *tbl)
   if (len && (diff & (1 << (len-1))) == 0)
     diff -= (1 << len) - 1;
   return diff;
+}
+
+// Decoder for third generation compressed SRW files (NX1)
+// Seriously Samsung just use lossless jpeg already, it compresses better too :)
+
+// Thanks to Michael Reichmann (Luminous Landscape) for putting me in contact
+// and Loring von Palleske (Samsung) for pointing to the open-source code of
+// Samsung's DNG converter at http://opensource.samsung.com/
+void SrwDecoder::decodeCompressed3( TiffIFD* raw)
+{
+  uint32 offset = raw->getEntry(STRIPOFFSETS)->getInt();
+  BitPumpMSB32 startpump(mFile->getData(offset),mFile->getSize() - offset);
+
+  // Process the initial metadata bits, we only really use initVal, width and
+  // height (the last two match the TIFF values anyway)
+  startpump.getBitsSafe(16); // NLCVersion
+  startpump.getBitsSafe(4);  // ImgFormat
+  uint32 bitDepth = startpump.getBitsSafe(4)+1;
+  startpump.getBitsSafe(4);  // NumBlkInRCUnit
+  startpump.getBitsSafe(4);  // CompressionRatio
+  uint32 width    = startpump.getBitsSafe(16);
+  uint32 height    = startpump.getBitsSafe(16);
+  startpump.getBitsSafe(16); // TileWidth
+  startpump.getBitsSafe(4);  // reserved
+  startpump.getBitsSafe(4);  // OptCode
+  startpump.getBitsSafe(8);  // OverlapWidth
+  startpump.getBitsSafe(8);  // reserved
+  startpump.getBitsSafe(8);  // Inc
+  startpump.getBitsSafe(2);  // reserved
+  uint32 initVal  = startpump.getBitsSafe(14);
+
+  mRaw->dim = iPoint2D(width, height);
+  mRaw->createData();
+
+  // The format is relatively straightforward. Each line gets encoded as a set 
+  // of differences from pixels from another line. Pixels are grouped in blocks 
+  // of 16 (8 green, 8 red or blue). Each block is encoded in three sections.
+  // First 1 or 4 bits to specify which reference pixels to use, then a section
+  // that specifies for each pixel the number of bits in the difference, then
+  // the actual difference bits
+  uint32 motion;
+  uint32 diffBitsMode[3][2] = {0};
+  uint32 line_offset = startpump.getOffset();
+  for (uint32 row=0; row < height; row++) {
+    // Align pump to 16byte boundary
+    if ((line_offset & 0xf) != 0)
+      line_offset += 16 - (line_offset & 0xf);
+    BitPumpMSB32 pump(mFile->getData(offset+line_offset),mFile->getSize()-offset-line_offset);
+
+    ushort16* img = (ushort16*)mRaw->getData(0, row);
+    ushort16* img_up = (ushort16*)mRaw->getData(0, max(0, (int)row - 1));
+    ushort16* img_up2 = (ushort16*)mRaw->getData(0, max(0, (int)row - 2));
+    // Initialize the motion and diff modes at the start of the line
+    motion = 7;
+    for (uint32 i=0; i<3; i++)
+      diffBitsMode[i][0] = diffBitsMode[i][1] = (row==0 || row==1) ? 7 : 4;
+
+    for (uint32 col=0; col < width; col += 16) {
+      // First we figure out which reference pixels mode we're in
+      if (!pump.getBitsSafe(1))
+        motion = pump.getBitsSafe(3);
+      if ((row==0 || row==1) && (motion != 7))
+        ThrowRDE("SRW Decoder: At start of image and motion isn't 7. File corrupted?");
+      if (motion == 7) {
+        // The base case, just set all pixels to the previous ones on the same line
+        // If we're at the left edge we just start at the initial value
+        for (uint32 i=0; i<16; i++) {
+          img[i] = (col == 0) ? initVal : *(img+i-2);
+        }
+      } else {
+        // The complex case, we now need to actually lookup one or two lines above
+        if (row < 2)
+          ThrowRDE("SRW: Got a previous line lookup on first two lines. File corrupted?");
+        int32 motionOffset[7] =    {-4,-2,-2,0,0,2,4};
+        int32 motionDoAverage[7] = { 0, 0, 1,0,1,0,0};
+
+        int32 slideOffset = motionOffset[motion];
+        int32 doAverage = motionDoAverage[motion];
+
+        for (uint32 i=0; i<16; i++) {
+          ushort16* refpixel;
+          if ((row+i) & 0x1) // Red or blue pixels use same color two lines up
+            refpixel = img_up2 + i + slideOffset;
+          else // Green pixel N uses Green pixel N from row above (top left or top right)
+            refpixel = img_up + i + slideOffset + ((i%2) ? -1 : 1);
+
+          // In some cases we use as reference interpolation of this pixel and the next
+          if (doAverage)
+            img[i] = (*refpixel + *(refpixel+2) + 1) >> 1;
+          else
+            img[i] = *refpixel;
+        }
+      }
+
+      // Figure out how many difference bits we have to read for each pixel
+      uint32 diffBits[4] = {0};
+      uint32 flags[4];
+      for (uint32 i=0; i<4; i++)
+        flags[i] = pump.getBitsSafe(2);
+      for (uint32 i=0; i<4; i++) {
+        // The color is 0-Green 1-Blue 2-Red
+        uint32 colornum = (row % 2 != 0) ? i>>1 : ((i>>1)+2) % 3;
+        switch(flags[i]) {
+          case 0: diffBits[i] = diffBitsMode[colornum][0]; break;
+          case 1: diffBits[i] = diffBitsMode[colornum][0]+1; break;
+          case 2: diffBits[i] = diffBitsMode[colornum][0]-1; break;
+          case 3: diffBits[i] = pump.getBitsSafe(4); break;
+        }
+        diffBitsMode[colornum][0] = diffBitsMode[colornum][1];
+        diffBitsMode[colornum][1] = diffBits[i];
+        if(diffBits[i] > bitDepth+1)
+          ThrowRDE("SRW Decoder: Too many difference bits. File corrupted?");
+      }
+
+      // Actually read the differences and write them to the pixels
+      for (uint32 i=0; i<16; i++) {
+        uint32 len = diffBits[i>>2];
+        int32 diff = pump.getBitsSafe(len);
+        // If the first bit is 1 we need to turn this into a negative number
+        if (diff >> (len-1))
+          diff -= (1 << len);
+        // Apply the diff to pixels 0 2 4 6 8 10 12 14 1 3 5 7 9 11 13 15
+        if (row % 2)
+          img[((i&0x7)<<1)+1-(i>>3)] += diff;
+        else
+          img[((i&0x7)<<1)+(i>>3)] += diff;
+      }
+
+      img += 16;
+      img_up += 16;
+      img_up2 += 16;
+    }
+    line_offset += pump.getOffset();
+  }
 }
 
 void SrwDecoder::checkSupportInternal(CameraMetaData *meta) {

--- a/RawSpeed/SrwDecoder.h
+++ b/RawSpeed/SrwDecoder.h
@@ -49,6 +49,7 @@ private:
   void decodeCompressed(TiffIFD* raw);
   void decodeCompressed2(TiffIFD* raw, int bits);
   int32 samsungDiff (BitPumpMSB &pump, encTableItem *tbl);
+  void decodeCompressed3(TiffIFD* raw);
   TiffIFD *mRootIFD;
   ByteStream *b;
 };

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3796,6 +3796,16 @@
 		<Crop x="0" y="2" width="-8" height="-22"/>
 		<Sensor black="0" white="16383"/>
 	</Camera>
+	<Camera make="SAMSUNG" model="NX1">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="128" white="16100"/>
+	</Camera>
 	<Camera make="SAMSUNG" model="NX5">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>


### PR DESCRIPTION
Samsung has yet again come up with a new compression format that's quirky and doesn't seem to compress particularly well. I figured out the format by reading the open-source code of the Samsung DNG converter found at opensource.samsung.com but the code is all new. I've verified that the decompressed output is identical.

The diff includes some whitespace changes as well as there were some spots using tabs instead of spaces.
