### PR TITLE
Fix broken compile

### DIFF
--- a/RawSpeed/RawImage.h
+++ b/RawSpeed/RawImage.h
@@ -63,7 +63,7 @@ public:
 
 class ImageMetaData {
 public:
-  ImageMetaData::ImageMetaData(void);
+  ImageMetaData(void);
 
   // Aspect ratio of the pixels, usually 1 but some cameras need scaling
   // <1 means the image needs to be stretched vertically, (0.5 means 2x)


### PR DESCRIPTION
I've needed to make this change to make the new metadata stuff compile. These last few updates also make darktable crash in weird ways. I'd guess something is trampling on memory somewhere.
