### PR TITLE
Add missing metadata initialization

### DIFF
--- a/RawSpeed/RawImage.cpp
+++ b/RawSpeed/RawImage.cpp
@@ -59,6 +59,7 @@ ImageMetaData::ImageMetaData(void) {
   subsampling.x = subsampling.y = 1;
   isoSpeed = 0;
   pixelAspectRatio = 1;
+  fujiRotationPos = 0;
   wbCoeffs[0] = NAN;
   wbCoeffs[1] = NAN;
   wbCoeffs[2] = NAN;


### PR DESCRIPTION
Found the bug that was causing darktable to crash. The rotation metadata had garbage on it because it wasn't initialized.
