### PR TITLE
Remove now unneeded override_cfa_black hint

### DIFF
--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -535,23 +535,6 @@ void RawDecoder::setMetaData(CameraMetaData *meta, string make, string model, st
       }
     }
   }
-
-  // Allow overriding individual blacklevels. Values are in CFA order
-  // (the same order as the in the CFA tag)
-  // A hint could be:
-  // <Hint name="override_cfa_black" value="10,20,30,20"/>
-  if (cam->hints.find(string("override_cfa_black")) != hints.end()) {
-    string rgb = cam->hints.find(string("override_cfa_black"))->second;
-    vector<string> v = split_string(rgb, ',');
-    if (v.size() != 4) {
-      mRaw->setError("Expected 4 values '10,20,30,20' as values for override_cfa_black hint.");
-    } else {
-      for (int i = 0; i < 4; i++) {
-        mRaw->blackLevelSeparate[i] = atoi(v[i].c_str());
-      }
-    }
-  }
-
 }
 
 


### PR DESCRIPTION
The old version wasn't crashing (it was the missing initialization) but this one is. Shall we just remove it as it turned out not to be needed?
