### PR TITLE
Add sRaw hints for Canon EOS 1D X

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -698,10 +698,18 @@
 	<Camera make="Canon" model="Canon EOS-1D X" mode="sRaw1">
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="sraw_new" value=""/>
+			<Hint name="invert_sraw_wb" value=""/>
+		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D X" mode="sRaw2">
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="sraw_new" value=""/>
+			<Hint name="invert_sraw_wb" value=""/>
+		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G1 X">
 		<CFA width="2" height="2">


### PR DESCRIPTION
1D X sraws require invert and sraw_new hinst as reported here: http://bugzilla.rawstudio.org/show_bug.cgi?id=625
