### PR TITLE
Add support for the Canon D2000

### DIFF
--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -225,13 +225,10 @@ void Cr2Decoder::checkSupportInternal(CameraMetaData *meta) {
   string make = data[0]->getEntry(MAKE)->getString();
   string model = data[0]->getEntry(MODEL)->getString();
 
-  if (model != "Canon EOS-1DS" && model != "Canon EOS-1D" && model != "EOS D2000C") {
-    data = mRootIFD->getIFDsWithTag((TiffTag)0xc5d8);
-    if (data.empty())
-      ThrowRDE("CR2 Decoder: No image data found");
-
+  // Check for sRaw mode
+  data = mRootIFD->getIFDsWithTag((TiffTag)0xc5d8);
+  if (!data.empty()) {
     TiffIFD* raw = data[0];
-
     if (raw->hasEntry((TiffTag)0xc6c5)) {
       ushort16 ss = raw->getEntry((TiffTag)0xc6c5)->getInt();
       if (ss == 4) {

--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -96,6 +96,18 @@ RawImage Cr2Decoder::decodeRawInternal() {
       mRaw = procRaw;
     }
 
+    if (!uncorrectedRawValues && mRootIFD->getEntryRecursive((TiffTag)0x123)) {
+      TiffEntry *curve = mRootIFD->getEntryRecursive((TiffTag)0x123);
+      if (curve->type == TIFF_SHORT && curve->count == 4096) {
+        const ushort16 *linearization = mRootIFD->getEntryRecursive((TiffTag)0x123)->getShortArray();
+        for (uint32 y = 0; y < height; y++) {
+          ushort16 *img = (ushort16*)mRaw->getData(0,y);
+          for (uint32 x = 0; x < width; x++)
+            img[x] = linearization[img[x]];
+        }
+      }
+    }
+
     return mRaw;
   }
 

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -640,6 +640,7 @@
 		<Sensor black="0" white="3588"/>
 		<Hints>
 			<Hint name="old_format" value=""/>
+			<Hint name="double_line_ljpeg" value=""/>
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1DS" decoder_version="5">
@@ -653,6 +654,21 @@
 		<Sensor black="0" white="3500"/>
 		<Hints>
 			<Hint name="old_format" value=""/>
+			<Hint name="double_line_ljpeg" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="EOS D2000C" decoder_version="5">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="96" white="4095"/>
+		<Hints>
+			<Hint name="old_format" value=""/>
+      <Hint name="override_whitebalance" value="1098961,1000000,1712802"/>
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark II">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -668,7 +668,7 @@
 		<Sensor black="96" white="4095"/>
 		<Hints>
 			<Hint name="old_format" value=""/>
-      <Hint name="override_whitebalance" value="1098961,1000000,1712802"/>
+      <Hint name="override_whitebalance" value="1003807,1000000,2468898"/>
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark II">


### PR DESCRIPTION
This continues on the 1D and 1DS work. I do find this line ugly:

``` C
if (model != "Canon EOS-1DS" && model != "Canon EOS-1D" && model != "EOS D2000C")
```

but I don't think we can use hints in checkSupportInternal
