### PR TITLE
Make it possible to detect cameras based on filesize.

### DIFF
--- a/RawSpeed/CameraMetaData.cpp
+++ b/RawSpeed/CameraMetaData.cpp
@@ -69,6 +69,16 @@ bool CameraMetaData::hasCamera(string make, string model, string mode) {
   return TRUE;
 }
 
+Camera* CameraMetaData::getChdkCamera(uint32 filesize) {
+  if (chdkCameras.end() == chdkCameras.find(filesize))
+    return NULL;
+  return chdkCameras[filesize];
+}
+
+bool CameraMetaData::hasChdkCamera(uint32 filesize) {
+  return chdkCameras.end() != chdkCameras.find(filesize);
+}
+
 void CameraMetaData::addCamera( Camera* cam )
 {
   string id = string(cam->make).append(cam->model).append(cam->mode);
@@ -77,6 +87,17 @@ void CameraMetaData::addCamera( Camera* cam )
     delete(cam);
   } else {
     cameras[id] = cam;
+  }
+  if (0 == cam->mode.compare("chdk")) {
+    if (cam->hints.find("filesize") == cam->hints.end()) {
+      writeLog(DEBUG_PRIO_WARNING, "CameraMetaData: CHDK camera: %s %s, no \"filesize\" hint set!\n", cam->make.c_str(), cam->model.c_str());
+    } else {
+      uint32 size;
+      stringstream fsize(cam->hints.find("filesize")->second);
+      fsize >> size;
+      chdkCameras[size] = cam;
+      // writeLog(DEBUG_PRIO_WARNING, "CHDK camera: %s %s size:%u\n", cam->make.c_str(), cam->model.c_str(), size);
+    }
   }
 }
 

--- a/RawSpeed/CameraMetaData.h
+++ b/RawSpeed/CameraMetaData.h
@@ -35,8 +35,11 @@ public:
   CameraMetaData(const char *docname);
   virtual ~CameraMetaData(void);
   map<string,Camera*> cameras;
+  map<uint32,Camera*> chdkCameras;
   Camera* getCamera(string make, string model, string mode);
   bool hasCamera(string make, string model, string mode);
+  Camera* getChdkCamera(uint32 filesize);
+  bool hasChdkCamera(uint32 filesize);
   void disableMake(string make);
   void disableCamera(string make, string model);
 protected:

--- a/RawSpeed/RawParser.cpp
+++ b/RawSpeed/RawParser.cpp
@@ -41,7 +41,7 @@ RawParser::RawParser(FileMap* inputData): mInput(inputData) {
 RawParser::~RawParser(void) {
 }
 
-RawDecoder* RawParser::getDecoder() {
+RawDecoder* RawParser::getDecoder(CameraMetaData* meta) {
   const unsigned char* data = mInput->getData(0);
   // We need some data.
   // For now it is 104 bytes for RAF images.
@@ -144,8 +144,14 @@ RawDecoder* RawParser::getDecoder() {
   } catch (CiffParserException) {
   }
 
-  // File could not be decoded, so no further options for now.
+  // Detect camera on filesize (CHDK).
+  if (meta != NULL && meta->hasChdkCamera(mInput->getSize())) {
+    Camera* c = meta->getChdkCamera(mInput->getSize());
 
+    // TODO: Create decoder and return
+  }
+
+  // File could not be decoded, so no further options for now.
   ThrowRDE("No decoder found. Sorry.");
   return NULL;
 }

--- a/RawSpeed/RawParser.h
+++ b/RawSpeed/RawParser.h
@@ -33,7 +33,7 @@ class RawParser
 public:
   RawParser(FileMap* input);
   virtual ~RawParser();
-  virtual RawDecoder* getDecoder();
+  virtual RawDecoder* getDecoder(CameraMetaData* meta = NULL);
   void ParseFuji(uint32 offset, TiffIFD *target_ifd);
 protected:
   FileMap *mInput;

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -5295,4 +5295,20 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="31456"/>
 	</Camera>
+	<!-- CHDK Cameras -->
+	<Camera make="AVT" model="F-201C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="1920000"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="1600"/>
+			<Hint name="full_height" value="1200"/>
+		</Hints>
+	</Camera>
+
 </Cameras>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -5296,6 +5296,34 @@
 		<Sensor black="0" white="31456"/>
 	</Camera>
 	<!-- CHDK Cameras -->
+	<Camera make="AVT" model="F-080C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="786432"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="1024"/>
+			<Hint name="full_height" value="768"/>
+		</Hints>
+	</Camera>
+	<Camera make="AVT" model="F-145C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="1447680"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="1392"/>
+			<Hint name="full_height" value="1040"/>
+		</Hints>
+	</Camera>
 	<Camera make="AVT" model="F-201C" mode="chdk">
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
@@ -5308,6 +5336,1293 @@
 			<Hint name="bits" value="8"/>
 			<Hint name="full_width" value="1600"/>
 			<Hint name="full_height" value="1200"/>
+		</Hints>
+	</Camera>
+	<Camera make="AVT" model="F-510C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="5067304"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="2588"/>
+			<Hint name="full_height" value="1958"/>
+		</Hints>
+	</Camera>
+	<Camera make="AVT" model="F-510C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="5067316"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="2588"/>
+			<Hint name="full_height" value="1958"/>
+			<Hint name="offset" value="12"/>
+		</Hints>
+	</Camera>
+	<Camera make="AVT" model="F-510C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="10134608"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="2588"/>
+			<Hint name="full_height" value="1958"/>
+		</Hints>
+	</Camera>
+	<Camera make="AVT" model="F-510C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="10134620"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="2588"/>
+			<Hint name="full_height" value="1958"/>
+			<Hint name="offset" value="12"/>
+		</Hints>
+	</Camera>
+	<Camera make="AVT" model="F-810C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="16157136"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="3272"/>
+			<Hint name="full_height" value="2469"/>
+		</Hints>
+	</Camera>
+	<Camera make="AgfaPhoto" model="DC-833m" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="15980544"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="3264"/>
+			<Hint name="full_height" value="2448"/>
+		</Hints>
+	</Camera>
+	<Camera make="Alcatel" model="5035D" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="9631728"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="2532"/>
+			<Hint name="full_height" value="1902"/>
+		</Hints>
+	</Camera>
+	<Camera make="Baumer" model="TXG14" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="2868726"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="1384"/>
+			<Hint name="full_height" value="1036"/>
+			<Hint name="offset" value="1078"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot SD300" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="12" y="12" width="-44" height="-2"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="5298000"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="2400"/>
+			<Hint name="full_height" value="1766"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A460" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="4" y="4" width="-44" height="-4"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="6553440"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="2664"/>
+			<Hint name="full_height" value="1968"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A610" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="12" y="8" width="-44" height="0"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="6573120"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="2672"/>
+			<Hint name="full_height" value="1968"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A530" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="10" y="6" width="-42" height="-2"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="6653280"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="2672"/>
+			<Hint name="full_height" value="1992"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot S3 IS" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="44" y="8" width="-4" height="0"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="7710960"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="2888"/>
+			<Hint name="full_height" value="2136"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A620" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="36" y="12" width="-4" height="0"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="9219600"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="3152"/>
+			<Hint name="full_height" value="2340"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A470" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="12" y="7" width="-44" height="-13"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="9243240"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="3152"/>
+			<Hint name="full_height" value="2346"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A720 IS" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="6" y="5" width="-32" height="-3"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="10341600"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="3336"/>
+			<Hint name="full_height" value="2480"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A630" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="12" y="6" width="-44" height="-6"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="10383120"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="3344"/>
+			<Hint name="full_height" value="2484"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A640" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="12" y="6" width="-52" height="-6"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="12945240"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="3736"/>
+			<Hint name="full_height" value="2772"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A650" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="48" y="12" width="-24" height="-12"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="15636240"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="4104"/>
+			<Hint name="full_height" value="3048"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot SX110 IS" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="6" y="12" width="-30" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="15467760"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3720"/>
+			<Hint name="full_height" value="2772"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot SX120 IS" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="12" y="9" width="-44" height="-9"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="15534576"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3728"/>
+			<Hint name="full_height" value="2778"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot SX20 IS" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="24" y="12" width="-24" height="-12"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="18653760"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="4080"/>
+			<Hint name="full_height" value="3048"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot SX220 HS" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="92" y="16" width="-4" height="-1"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="19131120"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="4168"/>
+			<Hint name="full_height" value="3060"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot SX30 IS" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">BG</ColorRow>
+			<ColorRow y="1">GR</ColorRow>
+		</CFA2>
+		<Crop x="25" y="10" width="-73" height="-12"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="21936096"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="4464"/>
+			<Hint name="full_height" value="3276"/>
+		</Hints>
+	</Camera>
+	<Camera make="Canon" model="PowerShot A3300 IS" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="8" y="16" width="-56" height="-8"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="24724224"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="4704"/>
+			<Hint name="full_height" value="3504"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="QV-2000UX" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="2" width="0" height="-1"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="1976352"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="1632"/>
+			<Hint name="full_height" value="1211"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="QV-3*00EX" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-10" height="-1"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="3217760"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="2080"/>
+			<Hint name="full_height" value="1547"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="QV-5700" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-9" height="0"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="6218368"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="2585"/>
+			<Hint name="full_height" value="1924"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z60" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">BG</ColorRow>
+			<ColorRow y="1">GR</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-34" height="-36"/>
+		<Sensor black="0" white="1023"/>
+		<Hints>
+			<Hint name="filesize" value="7816704"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="2867"/>
+			<Hint name="full_height" value="2181"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-S20" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-1" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="2937856"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="1621"/>
+			<Hint name="full_height" value="1208"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-S100" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-32" height="-34"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="4948608"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2090"/>
+			<Hint name="full_height" value="1578"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="QV-R41" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="2" y="0" width="-32" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="6054400"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2346"/>
+			<Hint name="full_height" value="1720"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-P505" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="7426656"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2568"/>
+			<Hint name="full_height" value="1928"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="QV-R51" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-22" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="7530816"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2602"/>
+			<Hint name="full_height" value="1929"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z50" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-32" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="7542528"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2602"/>
+			<Hint name="full_height" value="1932"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z500" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">BG</ColorRow>
+			<ColorRow y="1">GR</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-25" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="7562048"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2602"/>
+			<Hint name="full_height" value="1937"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z55" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-32" height="-26"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="7753344"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2602"/>
+			<Hint name="full_height" value="1986"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-P600" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-14" height="-30"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="9313536"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2858"/>
+			<Hint name="full_height" value="2172"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z750" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-27" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="10834368"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3114"/>
+			<Hint name="full_height" value="2319"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z75" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-25" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="10843712"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3114"/>
+			<Hint name="full_height" value="2321"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-P700" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-32" height="-32"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="10979200"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3114"/>
+			<Hint name="full_height" value="2350"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z850" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-6" height="-30"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="12310144"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3285"/>
+			<Hint name="full_height" value="2498"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z8" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-47" height="-35"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="12489984"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3328"/>
+			<Hint name="full_height" value="2502"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-Z1050" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-82" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="15499264"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3754"/>
+			<Hint name="full_height" value="2752"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="EX-ZR100" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-24" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="18702336"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="4096"/>
+			<Hint name="full_height" value="3044"/>
+		</Hints>
+	</Camera>
+	<Camera make="Casio" model="QV-4000" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="7684000"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="2260"/>
+			<Hint name="full_height" value="1700"/>
+		</Hints>
+	</Camera>
+	<Camera make="Creative" model="PC-CAM 600" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="1" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="787456"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="1024"/>
+			<Hint name="full_height" value="769"/>
+		</Hints>
+	</Camera>
+	<Camera make="DJI" model="" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="28829184"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="4384"/>
+			<Hint name="full_height" value="3288"/>
+		</Hints>
+	</Camera>
+	<Camera make="Matrix" model="" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="15151104"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="4608"/>
+			<Hint name="full_height" value="3288"/>
+		</Hints>
+	</Camera>
+	<Camera make="Foculus" model="531C" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="3840000"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="1600"/>
+			<Hint name="full_height" value="1200"/>
+		</Hints>
+	</Camera>
+	<Camera make="Generic" model="" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="307200"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="640"/>
+			<Hint name="full_height" value="480"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="DC20" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="1" y="1" width="-6" height="-1"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="62464"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="256"/>
+			<Hint name="full_height" value="244"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="DC20" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="1" y="1" width="-10" height="-1"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="124928"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="512"/>
+			<Hint name="full_height" value="244"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="DCS200" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="52" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="1652736"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="1536"/>
+			<Hint name="full_height" value="1076"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="C330" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="1" y="33" width="-1" height="-2"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="4159302"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="2338"/>
+			<Hint name="full_height" value="1779"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="C330" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="1" y="33" width="-1" height="-2"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="4162462"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="2338"/>
+			<Hint name="full_height" value="1779"/>
+			<Hint name="offset" value="3160"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="C603" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="6163328"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="2864"/>
+			<Hint name="full_height" value="2152"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="C603" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="6166488"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="2864"/>
+			<Hint name="full_height" value="2152"/>
+			<Hint name="offset" value="3160"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="C603" mode="chdk">
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="460800"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="640"/>
+			<Hint name="full_height" value="480"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="C603" mode="chdk">
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="9116448"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2848"/>
+			<Hint name="full_height" value="2134"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="12MP" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="2" y="0" width="0" height="-13"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="12241200"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="4040"/>
+			<Hint name="full_height" value="3030"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="12MP" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="2" y="0" width="0" height="-13"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="12272756"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="4040"/>
+			<Hint name="full_height" value="3030"/>
+			<Hint name="offset" value="31556"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="12MP" mode="chdk">
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="18000000"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="4000"/>
+			<Hint name="full_height" value="3000"/>
+		</Hints>
+	</Camera>
+	<Camera make="Kodak" model="KAI-0340" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="3" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="614400"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="640"/>
+			<Hint name="full_height" value="480"/>
+		</Hints>
+	</Camera>
+	<Camera make="Micron" model="2010" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">BG</ColorRow>
+			<ColorRow y="1">GR</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="3884928"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="1608"/>
+			<Hint name="full_height" value="1207"/>
+			<Hint name="offset" value="3212"/>
+		</Hints>
+	</Camera>
+	<Camera make="Minolta" model="RD175" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="63"/>
+		<Hints>
+			<Hint name="filesize" value="1138688"/>
+			<Hint name="bits" value="6"/>
+			<Hint name="full_width" value="1534"/>
+			<Hint name="full_height" value="986"/>
+			<Hint name="offset" value="513"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="E900" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">BG</ColorRow>
+			<ColorRow y="1">GR</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-18" height="-6"/>
+		<Sensor black="0" white="1008"/>
+		<Hints>
+			<Hint name="filesize" value="1581060"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="1305"/>
+			<Hint name="full_height" value="969"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="E950" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-22" height="-1"/>
+		<Sensor black="0" white="992"/>
+		<Hints>
+			<Hint name="filesize" value="2465792"/>
+			<Hint name="bits" value="10"/>
+			<Hint name="full_width" value="1638"/>
+			<Hint name="full_height" value="1204"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="E2100" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="-7"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="2940928"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="1616"/>
+			<Hint name="full_height" value="1213"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="E990" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="-1"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="4771840"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2064"/>
+			<Hint name="full_height" value="1541"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="E3700" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="4775936"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2064"/>
+			<Hint name="full_height" value="1542"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="E4500" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="-1"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="5865472"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2288"/>
+			<Hint name="full_height" value="1709"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="E4300" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">BG</ColorRow>
+			<ColorRow y="1">GR</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="5869568"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2288"/>
+			<Hint name="full_height" value="1710"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="E5000" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="-1"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="7438336"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2576"/>
+			<Hint name="full_height" value="1925"/>
+		</Hints>
+	</Camera>
+	<Camera make="Nikon" model="COOLPIX S6" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="8998912"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2832"/>
+			<Hint name="full_height" value="2118"/>
+		</Hints>
+	</Camera>
+	<Camera make="Olympus" model="C770UZ" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">BG</ColorRow>
+			<ColorRow y="1">GR</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="5939200"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2304"/>
+			<Hint name="full_height" value="1718"/>
+		</Hints>
+	</Camera>
+	<Camera make="Pentax" model="Optio S" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="3178560"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="2064"/>
+			<Hint name="full_height" value="1540"/>
+		</Hints>
+	</Camera>
+	<Camera make="Pentax" model="Optio S" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-22" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="4841984"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2090"/>
+			<Hint name="full_height" value="1544"/>
+		</Hints>
+	</Camera>
+	<Camera make="Pentax" model="Optio S4" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-22" height="0"/>
+		<Sensor black="0" white="3968"/>
+		<Hints>
+			<Hint name="filesize" value="6114240"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="2346"/>
+			<Hint name="full_height" value="1737"/>
+		</Hints>
+	</Camera>
+	<Camera make="Pentax" model="Optio 750Z" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="-21"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="filesize" value="10702848"/>
+			<Hint name="bits" value="12"/>
+			<Hint name="full_width" value="3072"/>
+			<Hint name="full_height" value="2322"/>
+		</Hints>
+	</Camera>
+	<Camera make="Pixelink" model="A782" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="13248000"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="2208"/>
+			<Hint name="full_height" value="3000"/>
+		</Hints>
+	</Camera>
+	<Camera make="RoverShot" model="3320AF" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="6291456"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="2048"/>
+			<Hint name="full_height" value="1536"/>
+		</Hints>
+	</Camera>
+	<Camera make="ST Micro" model="STV680 VGA" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">BG</ColorRow>
+			<ColorRow y="1">GR</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="311696"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="644"/>
+			<Hint name="full_height" value="484"/>
+		</Hints>
+	</Camera>
+	<Camera make="Samsung" model="S85" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-24" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="16098048"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="3288"/>
+			<Hint name="full_height" value="2448"/>
+		</Hints>
+	</Camera>
+	<Camera make="Samsung" model="S85" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-48" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="16215552"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="3312"/>
+			<Hint name="full_height" value="2448"/>
+		</Hints>
+	</Camera>
+	<Camera make="Samsung" model="WB550" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65504"/>
+		<Hints>
+			<Hint name="filesize" value="20487168"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="3648"/>
+			<Hint name="full_height" value="2808"/>
+		</Hints>
+	</Camera>
+	<Camera make="Samsung" model="WB550" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">RG</ColorRow>
+			<ColorRow y="1">GB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65504"/>
+		<Hints>
+			<Hint name="filesize" value="24000000"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="4000"/>
+			<Hint name="full_height" value="3000"/>
+		</Hints>
+	</Camera>
+	<Camera make="Sinar" model="" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="12582980"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="3072"/>
+			<Hint name="full_height" value="2048"/>
+			<Hint name="offset" value="68"/>
+		</Hints>
+	</Camera>
+	<Camera make="Sinar" model="" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="33292868"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="4080"/>
+			<Hint name="full_height" value="4080"/>
+			<Hint name="offset" value="68"/>
+		</Hints>
+	</Camera>
+	<Camera make="Sinar" model="" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="44390468"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="4080"/>
+			<Hint name="full_height" value="5440"/>
+			<Hint name="offset" value="68"/>
+		</Hints>
+	</Camera>
+	<Camera make="Sony" model="XCD-SX910CR" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-1" height="0"/>
+		<Sensor black="0" white="255"/>
+		<Hints>
+			<Hint name="filesize" value="1409024"/>
+			<Hint name="bits" value="8"/>
+			<Hint name="full_width" value="1376"/>
+			<Hint name="full_height" value="1024"/>
+		</Hints>
+	</Camera>
+	<Camera make="Sony" model="XCD-SX910CR" mode="chdk">
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GR</ColorRow>
+			<ColorRow y="1">BG</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-1" height="0"/>
+		<Sensor black="0" white="65535"/>
+		<Hints>
+			<Hint name="filesize" value="2818048"/>
+			<Hint name="bits" value="16"/>
+			<Hint name="full_width" value="1376"/>
+			<Hint name="full_height" value="1024"/>
 		</Hints>
 	</Camera>
 


### PR DESCRIPTION
Proposal for PR #44 

CameraMetaData must be sent to the getDecoder function. Otherwise chdk cameras will not be found.
