### PR TITLE
Added Olympus E-M5MarkII to the list of cameras 

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2394,6 +2394,16 @@
 		<Crop x="8" y="8" width="-24" height="-8"/>
 		<Sensor black="255" white="4095"/>
 	</Camera>
+	<Camera make="OLYMPUS IMAGING CORP." model="E-M5MarkII">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="8" y="8" width="-24" height="-8"/>
+		<Sensor black="255" white="4095"/>
+	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-P1">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>


### PR DESCRIPTION
The entry is copied from the "old" E-M5 entry, I just modified the camera model name to match the EXIF data. I am not sure about the other values. 
