### PR TITLE
Canon PowerShot G7 X: fix white balance reading

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -964,6 +964,9 @@
 		</CFA>
 		<Crop x="96" y="18" width="0" height="0"/>
 		<Sensor black="511" white="4000"/>
+		<Hints>
+			<Hint name="wb_offset" value="142"/>
+		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G1 X">
 		<CFA width="2" height="2">


### PR DESCRIPTION
(cherry picked from commit darktable-org/darktable@4231f0ae3e64269e37c064bf440eb0fa259861b5 and darktable-org/darktable@c8c771883c1e5b3ba9809b1b7db2a649fda077d7)
