### PR TITLE
Cleanup the ORF uncompressed code path

### DIFF
--- a/RawSpeed/OrfDecoder.h
+++ b/RawSpeed/OrfDecoder.h
@@ -44,7 +44,7 @@ public:
   virtual TiffIFD* getRootIFD() {return mRootIFD;}
 private:
   void decodeCompressed(ByteStream& s,uint32 w, uint32 h);
-  void decodeOldORF(TiffIFD* raw);
+  void decodeUncompressed(ByteStream& s,uint32 w, uint32 h, uint32 size, Endianness endian);
   TiffIFD *mRootIFD;
 };
 

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2240,7 +2240,7 @@
 		<Crop x="0" y="0" width="-6" height="-2"/>
 		<Sensor black="65" white="4015"/>
 	</Camera>
-	<Camera make="OLYMPUS IMAGING CORP." model="E-300">
+	<Camera make="OLYMPUS IMAGING CORP." model="E-300" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2251,9 +2251,10 @@
 		<Sensor black="63" white="4095"/>
 		<Hints>
 			<Hint name="force_uncompressed" value=""/>
+			<Hint name="packed_with_control" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="OLYMPUS IMAGING CORP." model="E-330">
+	<Camera make="OLYMPUS IMAGING CORP." model="E-330" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2262,6 +2263,10 @@
 		</CFA>
 		<Crop x="0" y="0" width="3250" height="2450"/>
 		<Sensor black="77" white="4095"/>
+		<Hints>
+			<Hint name="force_uncompressed" value=""/>
+			<Hint name="packed_with_control" value=""/>
+		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-400">
 		<CFA width="2" height="2">
@@ -2303,7 +2308,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="69" white="4015"/>
 	</Camera>
-	<Camera make="OLYMPUS IMAGING CORP." model="E-500">
+	<Camera make="OLYMPUS IMAGING CORP." model="E-500" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2314,6 +2319,7 @@
 		<Sensor black="63" white="3967"/>
 		<Hints>
 			<Hint name="force_uncompressed" value=""/>
+			<Hint name="packed_with_control" value=""/>
 		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-510">
@@ -2585,7 +2591,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="55" white="3972"/>
 	</Camera>
-	<Camera make="OLYMPUS IMAGING CORP." model="XZ-2" decoder_version="2">
+	<Camera make="OLYMPUS IMAGING CORP." model="XZ-2" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2596,6 +2602,7 @@
 		<Sensor black="200" white="4092"/>
 		<Hints>
 			<Hint name="force_uncompressed" value=""/>
+			<Hint name="jpeg32_bitorder" value=""/>
 		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="STYLUS1">


### PR DESCRIPTION
Turns out I had screwed up the support for at least the XZ-2 by overloading the meaning of the force_uncompressed hint. This fixes that and cleans up the messy code to have a single uncompressed code path that handles all the cases we know about so far. It creates two more hints in the process so the decoder version gets bumped.
