### PR TITLE
Fix some warnings found by latest clang

### DIFF
--- a/RawSpeed/ArwDecoder.cpp
+++ b/RawSpeed/ArwDecoder.cpp
@@ -335,7 +335,7 @@ void ArwDecoder::GetWB() {
 
     uint32 *ifp_data = (uint32 *) mFile->getDataWrt(off);
     uint32 pad[128];
-	  uint32 p;
+    uint32 p;
     // Initialize the decryption
     for (p=0; p < 4; p++)
       pad[p] = key = key * 48828125 + 1;
@@ -347,8 +347,11 @@ void ArwDecoder::GetWB() {
 
     // Decrypt the buffer in place
     uint32 count = len/4;
-    while (count--)
-      *ifp_data++ ^= (pad[p++ & 127] = pad[p & 127] ^ pad[(p+64) & 127]);
+    while (count--) {
+      pad[p & 127] = pad[(p+1) & 127] ^ pad[(p+1+64) & 127];
+      *ifp_data++ ^= pad[p & 127];
+      p++;
+    }
 
     if (mRootIFD->endian == getHostEndianness())
       sony_private = new TiffIFD(mFile, off);

--- a/RawSpeed/SrwDecoder.cpp
+++ b/RawSpeed/SrwDecoder.cpp
@@ -324,7 +324,7 @@ void SrwDecoder::decodeCompressed3( TiffIFD* raw)
   // that specifies for each pixel the number of bits in the difference, then
   // the actual difference bits
   uint32 motion;
-  uint32 diffBitsMode[3][2] = {0};
+  uint32 diffBitsMode[3][2] = {{0}};
   uint32 line_offset = startpump.getOffset();
   for (uint32 row=0; row < height; row++) {
     // Align pump to 16byte boundary

--- a/RawSpeed/X3fDecoder.cpp
+++ b/RawSpeed/X3fDecoder.cpp
@@ -212,7 +212,6 @@ void X3fDecoder::decompressSigma( X3fImage &image )
         if (plane_offset[i]>mFile->getSize())
           ThrowRDE("SigmaDecompressor:Plane offset outside image");
       }
-      const uchar8* start = mFile->getData(plane_offset[i]);
     }
     mRaw->clearArea(iRectangle2D(0,0,image.width,image.height));
 


### PR DESCRIPTION
Two warnings (Srw and X3f) are really minor cosmetic things. The Arw code however was depending on undefined behavior and was typically dense dcraw code that's now refactored.
