### PR TITLE
Small fix for the ORF WB calculations

### DIFF
--- a/RawSpeed/OrfDecoder.cpp
+++ b/RawSpeed/OrfDecoder.cpp
@@ -246,7 +246,7 @@ void OrfDecoder::decodeCompressed(ByteStream& s, uint32 w, uint32 h) {
         dest[x] = left1 = pred + ((diff << 2) | low);
         nw1 = up;
       }
-	    border = y_border;
+      border = y_border;
     }
   }
 }
@@ -287,7 +287,7 @@ void OrfDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
     // Newer cameras process the Image Processing SubIFD in the makernote
     if(mRootIFD->hasEntryRecursive(OLYMPUSIMAGEPROCESSING)) {
       TiffEntry *img_entry = mRootIFD->getEntryRecursive(OLYMPUSIMAGEPROCESSING);
-      uint32 offset = *((ushort16 *) img_entry->getData()) + img_entry->parent_offset - 12;
+      uint32 offset = img_entry->getInt() + img_entry->parent_offset - 12;
       TiffIFD *image_processing = NULL;
       try {
         if (mRootIFD->endian == getHostEndianness())

--- a/RawSpeed/TiffEntry.cpp
+++ b/RawSpeed/TiffEntry.cpp
@@ -107,7 +107,7 @@ bool TiffEntry::isInt() {
 }
 
 unsigned int TiffEntry::getInt() {
-  if (!(type == TIFF_LONG || type == TIFF_SHORT || type == TIFF_BYTE))
+  if (!(type == TIFF_LONG || type == TIFF_SHORT || type == TIFF_BYTE || type == TIFF_OFFSET))
     ThrowTPE("TIFF, getInt: Wrong type 0x%x encountered. Expected Long, Short or Byte", type);
   if (type == TIFF_BYTE)
     return getByte();

--- a/RawSpeed/TiffEntry.h
+++ b/RawSpeed/TiffEntry.h
@@ -46,19 +46,20 @@ const uint32 datashifts[] = {0,0,0,1,2,3,0,0,1,2, 3, 2, 3, 2};
  * Note: RATIONALs are the ratio of two 32-bit integer values.
  */
 typedef	enum {
-	TIFF_NOTYPE	= 0,	/* placeholder */
-	TIFF_BYTE	= 1,	/* 8-bit unsigned integer */
-	TIFF_ASCII	= 2,	/* 8-bit bytes w/ last byte null */
-	TIFF_SHORT	= 3,	/* 16-bit unsigned integer */
-	TIFF_LONG	= 4,	/* 32-bit unsigned integer */
-	TIFF_RATIONAL	= 5,	/* 64-bit unsigned fraction */
-	TIFF_SBYTE	= 6,	/* !8-bit signed integer */
-	TIFF_UNDEFINED	= 7,	/* !8-bit untyped data */
-	TIFF_SSHORT	= 8,	/* !16-bit signed integer */
-	TIFF_SLONG	= 9,	/* !32-bit signed integer */
-	TIFF_SRATIONAL	= 10,	/* !64-bit signed fraction */
-	TIFF_FLOAT	= 11,	/* !32-bit IEEE floating point */
-	TIFF_DOUBLE	= 12	/* !64-bit IEEE floating point */
+  TIFF_NOTYPE    = 0, /* placeholder */
+  TIFF_BYTE      = 1, /* 8-bit unsigned integer */
+  TIFF_ASCII     = 2, /* 8-bit bytes w/ last byte null */
+  TIFF_SHORT     = 3, /* 16-bit unsigned integer */
+  TIFF_LONG      = 4, /* 32-bit unsigned integer */
+  TIFF_RATIONAL  = 5, /* 64-bit unsigned fraction */
+  TIFF_SBYTE     = 6, /* !8-bit signed integer */
+  TIFF_UNDEFINED = 7, /* !8-bit untyped data */
+  TIFF_SSHORT    = 8, /* !16-bit signed integer */
+  TIFF_SLONG     = 9, /* !32-bit signed integer */
+  TIFF_SRATIONAL = 10, /* !64-bit signed fraction */
+  TIFF_FLOAT     = 11, /* !32-bit IEEE floating point */
+  TIFF_DOUBLE    = 12, /* !64-bit IEEE floating point */
+  TIFF_OFFSET    = 13, /* 32-bit unsigned offset used in ORF at least */
 } TiffDataType;
 
 

--- a/RawSpeed/TiffEntryBE.cpp
+++ b/RawSpeed/TiffEntryBE.cpp
@@ -79,7 +79,7 @@ TiffEntryBE::~TiffEntryBE(void) {
 }
 
 unsigned int TiffEntryBE::getInt() {
-  if (!(type == TIFF_LONG || type == TIFF_SHORT || type == TIFF_UNDEFINED))
+  if (!(type == TIFF_LONG || type == TIFF_SHORT || type == TIFF_UNDEFINED || type == TIFF_OFFSET))
     ThrowTPE("TIFF, getInt: Wrong type 0x%x encountered. Expected Int", type);
   if (type == TIFF_SHORT)
     return getShort();


### PR DESCRIPTION
We were only using 16bits before and it turns out that type 13 is a 32bit offset instead. This isn't an issue in actual files from cameras but exiftool generates files with larger offsets that trip this up. By using getInt() the code is also endian-clean whereas before it just did a cast.
