### PR TITLE
Add canonical names to cameras

### DIFF
--- a/RawSpeed/Camera.h
+++ b/RawSpeed/Camera.h
@@ -41,7 +41,12 @@ public:
   string make;
   string model;
   string mode;
+  string canonical_make;
+  string canonical_model;
+  string canonical_alias;
+  string canonical_id;
   vector<string> aliases;
+  vector<string> canonical_aliases;
   ColorFilterArray cfa;
   bool supported;
   iPoint2D cropSize;
@@ -54,6 +59,7 @@ protected:
   void parseCFA( pugi::xml_node &node );
   void parseAlias( pugi::xml_node &node );
   void parseHint( pugi::xml_node &node );
+  void parseID( pugi::xml_node &node );
   void parseBlackAreas( pugi::xml_node &node );
   void parseSensorInfo( pugi::xml_node &node );
   vector<int> MultipleStringToInt(const char *in, const char *tag, const char* attribute);

--- a/RawSpeed/DngDecoder.cpp
+++ b/RawSpeed/DngDecoder.cpp
@@ -505,17 +505,9 @@ void DngDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
     mRaw->metadata.isoSpeed = mRootIFD->getEntryRecursive(ISOSPEEDRATINGS)->getInt();
 
   // Set the make and model
-  if (!(mRootIFD->hasEntryRecursive(MAKE) && mRootIFD->hasEntryRecursive(MODEL))) {
-    if (mRootIFD->hasEntryRecursive(UNIQUECAMERAMODEL)) {
-      string unique = mRootIFD->getEntryRecursive(UNIQUECAMERAMODEL)->getString();
-      mRaw->metadata.canonical_make = mRaw->metadata.canonical_model = unique;
-      mRaw->metadata.canonical_alias = mRaw->metadata.canonical_id = unique;
-      mRaw->metadata.make = mRaw->metadata.model = unique;
-    }
-  } else {
-    vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-    string make = data[0]->getEntry(MAKE)->getString();
-    string model = data[0]->getEntry(MODEL)->getString();
+  if (mRootIFD->hasEntryRecursive(MAKE) && mRootIFD->hasEntryRecursive(MODEL)) {
+    string make = mRootIFD->getEntryRecursive(MAKE)->getString();
+    string model = mRootIFD->getEntryRecursive(MODEL)->getString();
     TrimSpaces(make);
     TrimSpaces(model);
     mRaw->metadata.make = make;
@@ -532,7 +524,11 @@ void DngDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
     } else {
       mRaw->metadata.canonical_make = make;
       mRaw->metadata.canonical_model = mRaw->metadata.canonical_alias = model;
-      mRaw->metadata.canonical_id = make + " " + model;
+      if (mRootIFD->hasEntryRecursive(UNIQUECAMERAMODEL)) {
+        mRaw->metadata.canonical_id = mRootIFD->getEntryRecursive(UNIQUECAMERAMODEL)->getString();
+      } else {
+        mRaw->metadata.canonical_id = make + " " + model;
+      }
     }
   }
 }

--- a/RawSpeed/MrwDecoder.cpp
+++ b/RawSpeed/MrwDecoder.cpp
@@ -27,10 +27,13 @@ namespace RawSpeed {
 
 MrwDecoder::MrwDecoder(FileMap* file) :
     RawDecoder(file) {
+  tiff_meta = NULL;
   parseHeader();
 }
 
 MrwDecoder::~MrwDecoder(void) {
+  if (tiff_meta)
+    delete tiff_meta;
 }
 
 int MrwDecoder::isMRW(FileMap* input) {
@@ -40,23 +43,6 @@ int MrwDecoder::isMRW(FileMap* input) {
   const uchar8* data = input->getData(0);
   return data[0] == 0x00 && data[1] == 0x4D && data[2] == 0x52 && data[3] == 0x4D;
 }
-                        
-/* This table includes all cameras that have ever had official MRW raw support.
-   There were also a few compacts (G400, G500, G530 and G600) that had a raw
-   mode in a hidden menu with MRW format written to JPG named files. It should
-   be easy to support them given example files but chances are it was more of a
-   novelty than something people actually used. */
-static mrw_camera_t mrw_camera_table[] = {
-  {"27820001", "DIMAGE A1"},
-  {"27200001", "DIMAGE A2"},
-  {"27470002", "DIMAGE A200"},
-  {"27730001", "DIMAGE 5"},
-  {"27660001", "DIMAGE 7"},
-  {"27790001", "DIMAGE 7I"},
-  {"27780001", "DIMAGE 7HI"},
-  {"21810002", "DYNAX 7D"},
-  {"21860002", "DYNAX 5D"},
-};
 
 void MrwDecoder::parseHeader() {
   const unsigned char* data = mFile->getData(0);
@@ -68,27 +54,39 @@ void MrwDecoder::parseHeader() {
     ThrowRDE("This isn't actually a MRW file, why are you calling me?");
     
   data_offset = get4BE(data,4)+8;
-  
-  // Let's just get all we need from the PRD block and be done with it
-  raw_height = get2BE(data,24);
-  raw_width = get2BE(data,26);
-  packed = (data[32] == 12);
-  cameraid = get8LE(data,16);
-  cameraName = modelName(cameraid);
-  if (!cameraName) {
-    uchar8 cameracode[9] = {0};
-    *((uint64 *) cameracode) = cameraid;
-    ThrowRDE("MRW decoder: Unknown camera with ID %s", cameracode);
-  }
-}
 
-const char* MrwDecoder::modelName(uint64 cameraid) {
-  for (uint32 i=0; i<sizeof(mrw_camera_table)/sizeof(mrw_camera_table[0]); i++) { 
-    if (*((uint64*) mrw_camera_table[i].code) == cameraid) {
-        return mrw_camera_table[i].name;
+  if (!mFile->isValid(data_offset))
+    ThrowRDE("MRW: Data offset is invalid");
+
+  // Make sure all values have at least been initialized
+  raw_width = raw_height = packed = 0;
+  wb_coeffs[0] = wb_coeffs[1] = wb_coeffs[2] = wb_coeffs[3] = NAN;
+
+  uint32 currpos = 8;
+  while (currpos < data_offset) {
+    uint32 tag = get4BE(data,currpos);
+    uint32 len = get4BE(data,currpos+4);
+    switch(tag) {
+    case 0x505244: // PRD
+      raw_height = get2BE(data,currpos+16);
+      raw_width = get2BE(data,currpos+18);
+      packed = (data[currpos+24] == 12);
+    case 0x574247: // WBG
+      for(uint32 i=0; i<4; i++)
+        wb_coeffs[i] = get2BE(data, currpos+12+i*2);
+      break;
+    case 0x545457: // TTW
+      // Base value for offsets needs to be at the beginning of the TIFF block, not the file
+      FileMap *f = new FileMap(mFile->getDataWrt(currpos+8), mFile->getSize()-currpos-8);
+      if (little == getHostEndianness())
+        tiff_meta = new TiffIFDBE(f, 8);
+      else
+        tiff_meta = new TiffIFD(f, 8);
+      delete f;
+      break;
     }
+    currpos += MAX(len+8,1); // MAX(,1) to make sure we make progress
   }
-  return NULL;
 }
 
 RawImage MrwDecoder::decodeRawInternal() {
@@ -123,35 +121,34 @@ RawImage MrwDecoder::decodeRawInternal() {
 }
 
 void MrwDecoder::checkSupportInternal(CameraMetaData *meta) {
-  this->checkCameraSupported(meta, "MINOLTA", cameraName, "");
+  if (!tiff_meta->hasEntry(MAKE) || !tiff_meta->hasEntry(MODEL))
+    ThrowRDE("MRW: Couldn't find make and model");
+
+  string make = tiff_meta->getEntry(MAKE)->getString();
+  string model = tiff_meta->getEntry(MODEL)->getString();
+  this->checkCameraSupported(meta, make, model, "");
 }
 
 void MrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   //Default
   int iso = 0;
 
-  setMetaData(meta, "MINOLTA", cameraName, "", iso);
+  if (!tiff_meta->hasEntry(MAKE) || !tiff_meta->hasEntry(MODEL))
+    ThrowRDE("MRW: Couldn't find make and model");
 
-  uint32 currpos = 8;
-  const unsigned char* data = mFile->getData(0);
-  while (currpos < data_offset) {
-    uint32 tag = get4BE(data,currpos);
-    uint32 len = get4BE(data,currpos+4);
-    if (tag == 0x574247) { /* WBG */
-      ushort16 tmp[4];
-      for(uint32 i=0; i<4; i++)
-        tmp[i] = get2BE(data, currpos+12+i*2);
-      if (!strcmp(cameraName,"DIMAGE A200")) {
-        mRaw->metadata.wbCoeffs[0] = (float) tmp[2];
-        mRaw->metadata.wbCoeffs[1] = (float) tmp[0];
-        mRaw->metadata.wbCoeffs[2] = (float) tmp[1];
-      } else {
-        mRaw->metadata.wbCoeffs[0] = (float) tmp[0];
-        mRaw->metadata.wbCoeffs[1] = (float) tmp[1];
-        mRaw->metadata.wbCoeffs[2] = (float) tmp[3];
-      }
-    }
-    currpos += MAX(len+8,1); // MAX(,1) to make sure we make progress
+  string make = tiff_meta->getEntry(MAKE)->getString();
+  string model = tiff_meta->getEntry(MODEL)->getString();
+
+  setMetaData(meta, make, model, "", iso);
+
+  if (hints.find("swapped_wb") != hints.end()) {
+    mRaw->metadata.wbCoeffs[0] = (float) wb_coeffs[2];
+    mRaw->metadata.wbCoeffs[1] = (float) wb_coeffs[0];
+    mRaw->metadata.wbCoeffs[2] = (float) wb_coeffs[1];
+  } else {
+    mRaw->metadata.wbCoeffs[0] = (float) wb_coeffs[0];
+    mRaw->metadata.wbCoeffs[1] = (float) wb_coeffs[1];
+    mRaw->metadata.wbCoeffs[2] = (float) wb_coeffs[3];
   }
 }
 

--- a/RawSpeed/MrwDecoder.h
+++ b/RawSpeed/MrwDecoder.h
@@ -24,6 +24,7 @@
 #define MRW_DECODER_H
 
 #include "RawDecoder.h"
+#include "TiffIFDBE.h"
 
 namespace RawSpeed {
 
@@ -45,9 +46,8 @@ public:
 protected:
   virtual void parseHeader();
   uint32 raw_width, raw_height, data_offset, packed;
-  uint64 cameraid;
-  const char* cameraName;
-  static const char* modelName(uint64 cameraid);
+  TiffIFD *tiff_meta;
+  float wb_coeffs[4];
 };
 
 } // namespace RawSpeed

--- a/RawSpeed/RafDecoder.cpp
+++ b/RawSpeed/RafDecoder.cpp
@@ -216,6 +216,12 @@ void RafDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   mRaw->whitePoint = sensor->mWhiteLevel;
   mRaw->blackAreas = cam->blackAreas;
   mRaw->cfa = cam->cfa;
+  mRaw->metadata.canonical_make = cam->canonical_make;
+  mRaw->metadata.canonical_model = cam->canonical_model;
+  mRaw->metadata.canonical_alias = cam->canonical_alias;
+  mRaw->metadata.canonical_id = cam->canonical_id;
+  mRaw->metadata.make = make;
+  mRaw->metadata.model = model;
 
   if (mRootIFD->hasEntryRecursive(FUJI_WB_GRBLEVELS)) {
     TiffEntry *wb = mRootIFD->getEntryRecursive(FUJI_WB_GRBLEVELS);

--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -511,6 +511,14 @@ void RawDecoder::setMetaData(CameraMetaData *meta, string make, string model, st
   }
 
   mRaw->cfa = cam->cfa;
+  mRaw->metadata.canonical_make = cam->canonical_make;
+  mRaw->metadata.canonical_model = cam->canonical_model;
+  mRaw->metadata.canonical_alias = cam->canonical_alias;
+  mRaw->metadata.canonical_id = cam->canonical_id;
+  mRaw->metadata.make = make;
+  mRaw->metadata.model = model;
+  mRaw->metadata.mode = mode;
+
   if (applyCrop) {
     iPoint2D new_size = cam->cropSize;
 

--- a/RawSpeed/RawImage.h
+++ b/RawSpeed/RawImage.h
@@ -84,6 +84,11 @@ public:
   string model;
   string mode;
 
+  string canonical_make;
+  string canonical_model;
+  string canonical_alias;
+  string canonical_id;
+
   // ISO speed. If known the value is set, otherwise it will be '0'.
   int isoSpeed;
 

--- a/cameras-xml.md
+++ b/cameras-xml.md
@@ -4,6 +4,7 @@ The camera definition file is used for decoding images which doesn’t require a
 
 ```xml
 <Camera make="Panasonic" model="DMC-FZ45" mode="4:3" supported="yes" decoder_version="0">
+  <ID make="Panasonic" model="DMC-FZ45">Panasonic DMC-FZ45</ID>
   <CFA width="2" height="2">
     <Color x="0" y="0">GREEN</Color><Color x="1" y="0">BLUE</Color>
     <Color x="0" y="1">RED</Color><Color x="1" y="1">GREEN</Color>
@@ -18,7 +19,7 @@ The camera definition file is used for decoding images which doesn’t require a
     <Hint name="coolpixsplit" value=""/>
   </Hints>
   <Aliases>
-    <Alias>DMC-FZ40</Alias>
+    <Alias id="DMC-FZ40">DMC-FZ40</Alias>
   </Aliases>
 </Camera>
 ```
@@ -27,7 +28,9 @@ Let’s go through it line for line:
 
 ##Camera Name
 
+```xml
 <Camera make="Panasonic" model="DMC-FZ45" mode="4:3" supported="yes" decoder_version="0">
+```
 
 This the basic camera identification. In this the make and model are required. This must be exactly as specified in the EXIF data of the file.
 
@@ -36,6 +39,14 @@ Mode refers to specific decoder modes which are special for each manufacturer. F
 The supported tag specifies whether a camera is supported. If this tag isn’t added it is assumed to be supported.
 
 The decoder_version is a possibility to disable decoding, if the decoder version is too old to properly decode the images from this camera. If the code version of RawSpeed is too old to decode this camera type, it will refuse to do so. If this isn’t specified it is assumed that all older versions of RawSpeed can decode the image.
+
+##Camera ID
+
+```xml
+<ID make="Panasonic" model="DMC-FZ45">Panasonic DMC-FZ45</ID>
+```
+
+This sets the canonical name for the camera. The content of the tag should be the same as the UniqueCameraModel DNG field in the Adobe DNG converted raw file and can be used to match the camera against DCP files or other external references. The make and model attributes are clean names (no repetitions, spurious words, etc) that can be used in UI. If the Alias tag is omitted the make and model from the Camera tag are used instead (joined with a space for UniqueCameraModel), so in this particular case the tag is actually not needed.
 
 ##CFA Colors
 
@@ -113,8 +124,8 @@ This may contain manufacturer-specific hints for decoding. This can result in th
 
 ```xml
   <Aliases>
-    <Alias>DMC-FZ40</Alias>
+    <Alias id="DMC-FZ40">DMC-FZ40</Alias>
   </Aliases>
 ```
 
-This is a possibility to add one or more model aliases for a camera, which may have different model names in different regions.
+This is a possibility to add one or more model aliases for a camera, which may have different model names in different regions. The id attribute specifies the clean model name for this alias, if ommited defaults to alias value (so in this case is not really needed).

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -337,6 +337,36 @@
 			<Alias>Canon EOS Kiss X7i</Alias>
 		</Aliases>
 	</Camera>
+	<Camera make="Canon" model="Canon EOS 750D">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="72" y="34" width="0" height="0"/>
+		<Sensor black="2047" white="11765" iso_min="0" iso_max = "199"/>
+		<Sensor black="2047" white="14580"/>
+		<Aliases>
+			<Alias>Canon EOS Rebel T6i</Alias>
+			<Alias>Canon EOS Kiss X8i</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="Canon" model="Canon EOS 760D">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="72" y="34" width="0" height="0"/>
+		<Sensor black="2047" white="11765" iso_min="0" iso_max = "199"/>
+		<Sensor black="2047" white="14580"/>
+		<Aliases>
+			<Alias>Canon EOS Rebel T6s</Alias>
+			<Alias>Canon EOS 8000D</Alias>
+		</Aliases>
+	</Camera>
 	<Camera make="Canon" model="Canon EOS 500D">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -1766,7 +1796,10 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="600" white="15892"/>
+		<Hints>
+			<Hint name="nikon_override_auto_black" value=""/>
+		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D70s">
 		<CFA width="2" height="2">
@@ -2088,7 +2121,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P330" supported="yes" decoder_version="5">
+	<Camera make="NIKON" model="COOLPIX P330" decoder_version="5">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2112,7 +2145,7 @@
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P6000" supported="yes" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P6000" decoder_version="1">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2126,7 +2159,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7000" supported="yes" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P7000" decoder_version="1">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2142,7 +2175,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7100" supported="yes" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P7100" decoder_version="1">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2158,7 +2191,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7700" supported="yes" decoder_version="5">
+	<Camera make="NIKON" model="COOLPIX P7700" decoder_version="5">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2172,7 +2205,7 @@
 			<Hint name="real_bpp" value="16"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7800" supported="yes" decoder_version="5">
+	<Camera make="NIKON" model="COOLPIX P7800" decoder_version="5">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2639,6 +2672,20 @@
 			<Hint name="jpeg32_bitorder" value=""/>
 		</Hints>
 	</Camera>
+	<Camera make="OLYMPUS IMAGING CORP." model="XZ-10" decoder_version="3">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="200" white="3900"/>
+		<Hints>
+			<Hint name="force_uncompressed" value=""/>
+			<Hint name="jpeg32_bitorder" value=""/>
+		</Hints>
+	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="SP570UZ">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -2664,26 +2711,26 @@
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-CM1">
 		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
+			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
+			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="15" white="4095"/>
+		<Sensor black="142" white="4095"/>
 		<Hints>
 			<Hint name="zero_is_bad" value=""/>
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-CM1" mode="3:2">
 		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
+			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
+			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="15" white="4095"/>
+		<Sensor black="142" white="4095"/>
 		<Hints>
 			<Hint name="zero_is_bad" value=""/>
 		</Hints>
@@ -3318,7 +3365,37 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">RED</Color>
 		</CFA>
-		<Crop x="0" y="0" width="-208" height="0"/>
+		<Crop x="8" y="8" width="4592" height="3448"/>
+		<Sensor black="143" white="4095"/>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-GM5" mode="3:2">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="8" y="8" width="4592" height="3064"/>
+		<Sensor black="143" white="4095"/>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-GM5" mode="16:9">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="8" y="8" width="4592" height="2584"/>
+		<Sensor black="143" white="4095"/>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-GM5" mode="1:1">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="8" y="8" width="3424" height="3424"/>
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-G3" mode="4:3">
@@ -3642,6 +3719,32 @@
 		</CFA>
 		<Crop x="0" y="0" width="-208" height="0"/>
 		<Sensor black="150" white="3956"/>
+		<Hints>
+			<Hint name="zero_is_bad" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-GF7">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-208" height="0"/>
+		<Sensor black="143" white="4095"/>
+		<Hints>
+			<Hint name="zero_is_bad" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-GF7" mode="4:3">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-208" height="0"/>
+		<Sensor black="143" white="4095"/>
 		<Hints>
 			<Hint name="zero_is_bad" value=""/>
 		</Hints>
@@ -5346,7 +5449,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="SONY" model="DSLR-A450" supported="yes">
+	<Camera make="SONY" model="DSLR-A450">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5396,7 +5499,7 @@
 		<Crop x="0" y="0" width="-2" height="-2"/>
 		<Sensor black="520" white="16596"/>
 	</Camera>
-	<Camera make="SONY" model="DSLR-A700" supported="yes">
+	<Camera make="SONY" model="DSLR-A700">
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5406,7 +5509,7 @@
 		<Crop x="0" y="0" width="4288" height="2856"/>
 		<Sensor black="520" white="16383"/>
 	</Camera>
-	<Camera make="SONY" model="DSLR-A850" supported="yes">
+	<Camera make="SONY" model="DSLR-A850">
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5416,7 +5519,7 @@
 		<Crop x="0" y="0" width="6080" height="4048"/>
 		<Sensor black="500" white="15000"/>
 	</Camera>
-	<Camera make="SONY" model="DSLR-A900" supported="yes">
+	<Camera make="SONY" model="DSLR-A900">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5426,7 +5529,7 @@
 		<Crop x="0" y="0" width="6080" height="4048"/>
 		<Sensor black="520" white="16383"/>
 	</Camera>
-	<Camera make="SONY" model="NEX-3" supported="yes">
+	<Camera make="SONY" model="NEX-3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5446,7 +5549,7 @@
 		<Crop x="0" y="0" width="-10" height="0"/>
 		<Sensor black="520" white="16596"/>
 	</Camera>
-	<Camera make="SONY" model="NEX-5" supported="yes">
+	<Camera make="SONY" model="NEX-5">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5456,7 +5559,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="520" white="16383"/>
 	</Camera>
-	<Camera make="SONY" model="NEX-5N" supported="yes">
+	<Camera make="SONY" model="NEX-5N">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5466,7 +5569,7 @@
 		<Crop x="0" y="0" width="-12" height="0"/>
 		<Sensor black="520" white="16596"/>
 	</Camera>
-	<Camera make="SONY" model="NEX-5R" supported="yes">
+	<Camera make="SONY" model="NEX-5R">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5476,7 +5579,7 @@
 		<Crop x="0" y="0" width="-12" height="0"/>
 		<Sensor black="520" white="16596"/>
 	</Camera>
-	<Camera make="SONY" model="NEX-5T" supported="yes">
+	<Camera make="SONY" model="NEX-5T">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5486,7 +5589,7 @@
 		<Crop x="0" y="0" width="-12" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
-	<Camera make="SONY" model="NEX-6" supported="yes">
+	<Camera make="SONY" model="NEX-6">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5497,7 +5600,7 @@
 		<Sensor black="520" white="16596"/>
 	</Camera>
 	<!-- Measured on images from https://github.com/klauspost/rawspeed/issues/78 -->
-	<Camera make="SONY" model="NEX-7" supported="yes">
+	<Camera make="SONY" model="NEX-7">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5507,7 +5610,7 @@
 		<Crop x="0" y="0" width="-26" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
-	<Camera make="SONY" model="NEX-C3" supported="yes">
+	<Camera make="SONY" model="NEX-C3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5517,7 +5620,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="520" white="16596"/>
 	</Camera>
-	<Camera make="SONY" model="NEX-F3" supported="yes">
+	<Camera make="SONY" model="NEX-F3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5527,7 +5630,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="520" white="16360"/>
 	</Camera>
-	<Camera make="SONY" model="ILCE-3000" supported="yes">
+	<Camera make="SONY" model="ILCE-3000">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5537,7 +5640,7 @@
 		<Crop x="0" y="0" width="-34" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
-	<Camera make="SONY" model="ILCE-3500" supported="yes">
+	<Camera make="SONY" model="ILCE-3500">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5547,7 +5650,7 @@
 		<Crop x="0" y="0" width="-34" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
-	<Camera make="SONY" model="ILCE-5000" supported="yes">
+	<Camera make="SONY" model="ILCE-5000">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5567,7 +5670,7 @@
 		<Crop x="0" y="0" width="-26" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
-	<Camera make="SONY" model="ILCE-6000" supported="yes">
+	<Camera make="SONY" model="ILCE-6000">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5577,7 +5680,7 @@
 		<Crop x="0" y="0" width="-28" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
-	<Camera make="SONY" model="ILCE-7" supported="yes">
+	<Camera make="SONY" model="ILCE-7">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5597,7 +5700,7 @@
 		<Crop x="0" y="0" width="-26" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
-	<Camera make="SONY" model="ILCE-7R" supported="yes">
+	<Camera make="SONY" model="ILCE-7R">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5607,7 +5710,7 @@
 		<Crop x="0" y="0" width="-26" height="0"/>
 		<Sensor black="512" white="16300"/>
 	</Camera>
-	<Camera make="SONY" model="ILCE-7S" supported="yes">
+	<Camera make="SONY" model="ILCE-7S">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -13,7 +13,7 @@
 <!DOCTYPE Cameras [
 <!ELEMENT BlackAreas ( Vertical*, Horizontal* ) >
 
-<!ELEMENT Camera ( CFA?, CFA2?, Crop, Sensor+, BlackAreas?, Aliases?, Hints? ) >
+<!ELEMENT Camera ( CFA?, CFA2?, Crop, Sensor+, BlackAreas?, Aliases?, Hints?, ID? ) >
 <!ATTLIST Camera make CDATA #REQUIRED >
 <!ATTLIST Camera model CDATA #REQUIRED >
 <!ATTLIST Camera supported CDATA #IMPLIED >
@@ -66,11 +66,17 @@
 <!ATTLIST Hint value CDATA #REQUIRED >
 
 <!ELEMENT Aliases ( Alias+ ) >
+<!ATTLIST Alias id CDATA #IMPLIED >
 <!ELEMENT Alias (#PCDATA) >
+
+<!ELEMENT ID (#PCDATA) >
+<!ATTLIST Camera make CDATA #REQUIRED >
+<!ATTLIST Camera model CDATA #REQUIRED >
 ]>
 
 <Cameras>
 	<Camera make="Canon" model="Canon EOS 100D">
+		<ID make="Canon" model="EOS 100D">Canon EOS 100D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -84,11 +90,12 @@
 			<Horizontal y="8" height="44"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS REBEL SL1</Alias>
-			<Alias>Canon EOS Kiss X7</Alias>
+			<Alias id="EOS Rebel SL1">Canon EOS REBEL SL1</Alias>
+			<Alias id="EOS Kiss X7">Canon EOS Kiss X7</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 300D DIGITAL">
+		<ID make="Canon" model="EOS 300D">Canon EOS 300D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -102,10 +109,12 @@
 			<Horizontal y="0" height="10"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS DIGITAL REBEL</Alias>
+			<Alias id="EOS Digital Rebel">Canon EOS DIGITAL REBEL</Alias>
+			<Alias id="EOS Kiss Digital">Canon EOS Kiss Digital</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS D30">
+		<ID make="Canon" model="EOS D30">Canon EOS D30</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -122,6 +131,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS D60">
+		<ID make="Canon" model="EOS D60">Canon EOS D60</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -136,6 +146,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 10D">
+		<ID make="Canon" model="EOS 10D">Canon EOS 10D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -146,6 +157,7 @@
 		<Sensor black="127" white="4000"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 20D">
+		<ID make="Canon" model="EOS 20D">Canon EOS 20D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -163,6 +175,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 30D">
+		<ID make="Canon" model="EOS 30D">Canon EOS 30D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -177,6 +190,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 350D DIGITAL">
+		<ID make="Canon" model="EOS 350D">Canon EOS 350D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -193,12 +207,13 @@
 			<Horizontal y="0" height="12"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS DIGITAL REBEL XT</Alias>
-			<Alias>Canon EOS Kiss Digital N</Alias>
-			<Alias>Canon EOS 350D</Alias>
+			<Alias id="Digital Rebel XT">Canon EOS DIGITAL REBEL XT</Alias>
+			<Alias id="Kiss Digital N">Canon EOS Kiss Digital N</Alias>
+			<Alias id="EOS 350D">Canon EOS 350D</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 40D" decoder_version="2">
+		<ID make="Canon" model="EOS 40D">Canon EOS 40D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -213,6 +228,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 40D" mode="sRaw1">
+		<ID make="Canon" model="EOS 40D">Canon EOS 40D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 		<Hints>
@@ -220,6 +236,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 40D" mode="sRaw2">
+		<ID make="Canon" model="EOS 40D">Canon EOS 40D</ID>
 		<Crop x="0" y="0" width="1944" height="1296"/>
 		<Sensor black="0" white="65535"/>
 		<Hints>
@@ -227,6 +244,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 450D">
+		<ID make="Canon" model="EOS 450D">Canon EOS 450D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -236,12 +254,13 @@
 		<Crop x="22" y="18" width="4290" height="2856"/>
 		<Sensor black="1020" white="14500"/>
 		<Aliases>
-			<Alias>Canon EOS DIGITAL REBEL XSi</Alias>
-			<Alias>Canon EOS Kiss Digital X2</Alias>
-			<Alias>Canon EOS Kiss X2</Alias>
+			<Alias id="Digital Rebel XSi">Canon EOS DIGITAL REBEL XSi</Alias>
+			<Alias id="Kiss Digital X2">Canon EOS Kiss Digital X2</Alias>
+			<Alias id="Kiss X2">Canon EOS Kiss X2</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 50D" decoder_version="1">
+		<ID make="Canon" model="EOS 50D">Canon EOS 50D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -256,14 +275,17 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 50D" mode="sRaw1">
+		<ID make="Canon" model="EOS 50D">Canon EOS 50D</ID>
 		<Crop x="0" y="0" width="3272" height="2178"/>
 		<Sensor black="0" white="53000"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 50D" mode="sRaw2">
+		<ID make="Canon" model="EOS 50D">Canon EOS 50D</ID>
 		<Crop x="0" y="0" width="2376" height="1584"/>
 		<Sensor black="0" white="53000"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 60D" decoder_version="1">
+		<ID make="Canon" model="EOS 60D">Canon EOS 60D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -278,14 +300,17 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 60D" mode="sRaw1">
+		<ID make="Canon" model="EOS 60D">Canon EOS 60D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 60D" mode="sRaw2">
+		<ID make="Canon" model="EOS 60D">Canon EOS 60D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 70D" decoder_version="1">
+		<ID make="Canon" model="EOS 70D">Canon EOS 70D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -302,6 +327,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 70D" mode="sRaw1">
+		<ID make="Canon" model="EOS 70D">Canon EOS 70D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="53000"/>
 		<Hints>
@@ -310,6 +336,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 70D" mode="sRaw2">
+		<ID make="Canon" model="EOS 70D">Canon EOS 70D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="53000"/>
 		<Hints>
@@ -318,6 +345,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 700D">
+		<ID make="Canon" model="EOS 700D">Canon EOS 700D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -333,11 +361,12 @@
 			<Horizontal y="4" height="50"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS REBEL T5i</Alias>
-			<Alias>Canon EOS Kiss X7i</Alias>
+			<Alias id="EOS Rebel T5i">Canon EOS REBEL T5i</Alias>
+			<Alias id="EOS Kiss X7i">Canon EOS Kiss X7i</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 750D">
+		<ID make="Canon" model="EOS 750D">Canon EOS 750D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -348,11 +377,12 @@
 		<Sensor black="2047" white="11765" iso_min="0" iso_max = "199"/>
 		<Sensor black="2047" white="14580"/>
 		<Aliases>
-			<Alias>Canon EOS Rebel T6i</Alias>
-			<Alias>Canon EOS Kiss X8i</Alias>
+			<Alias id="EOS Rebel T6i">Canon EOS Rebel T6i</Alias>
+			<Alias id="EOS Kiss X8i">Canon EOS Kiss X8i</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 760D">
+		<ID make="Canon" model="EOS 760D">Canon EOS 760D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -363,11 +393,12 @@
 		<Sensor black="2047" white="11765" iso_min="0" iso_max = "199"/>
 		<Sensor black="2047" white="14580"/>
 		<Aliases>
-			<Alias>Canon EOS Rebel T6s</Alias>
-			<Alias>Canon EOS 8000D</Alias>
+			<Alias id="EOS Rebel T6s">Canon EOS Rebel T6s</Alias>
+			<Alias id="EOS 8000D">Canon EOS 8000D</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 500D">
+		<ID make="Canon" model="EOS 500D">Canon EOS 500D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -381,11 +412,12 @@
 			<Horizontal y="2" height="22"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS REBEL T1i</Alias>
-			<Alias>Canon EOS Kiss X3</Alias>
+			<Alias id="EOS Rebel T1i">Canon EOS REBEL T1i</Alias>
+			<Alias id="EOS Kiss X3">Canon EOS Kiss X3</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 550D">
+		<ID make="Canon" model="EOS 550D">Canon EOS 550D</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="0">BLUE</Color>
 			<Color x="0" y="0">GREEN</Color>
@@ -399,11 +431,12 @@
 			<Horizontal y="4" height="44"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS REBEL T2i</Alias>
-			<Alias>Canon EOS Kiss X4</Alias>
+			<Alias id="EOS Rebel T2i">Canon EOS REBEL T2i</Alias>
+			<Alias id="EOS Kiss X4">Canon EOS Kiss X4</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 600D">
+		<ID make="Canon" model="EOS 600D">Canon EOS 600D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -418,11 +451,12 @@
 			<Horizontal y="4" height="44"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS REBEL T3i</Alias>
-			<Alias>Canon EOS Kiss X5</Alias>
+			<Alias id="EOS Rebel T3i">Canon EOS REBEL T3i</Alias>
+			<Alias id="EOS Kiss X5">Canon EOS Kiss X5</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 650D">
+		<ID make="Canon" model="EOS 650D">Canon EOS 650D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -437,11 +471,12 @@
 			<Horizontal y="4" height="44"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS REBEL T4i</Alias>
-			<Alias>Canon EOS Kiss X6i</Alias>
+			<Alias id="EOS Rebel T4i">Canon EOS REBEL T4i</Alias>
+			<Alias id="EOS Kiss X6i">Canon EOS Kiss X6i</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 5D">
+		<ID make="Canon" model="EOS 5D">Canon EOS 5D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -456,6 +491,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 5D Mark II" decoder_version="1">
+		<ID make="Canon" model="EOS 5D Mark II">Canon EOS 5D Mark II</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -471,16 +507,19 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 5D Mark II" mode="sRaw1">
+		<ID make="Canon" model="EOS 5D Mark II">Canon EOS 5D Mark II</ID>
 		<Crop x="0" y="0" width="3872" height="2574"/>
 		<Sensor black="0" white="57200" iso_list="160 320 640 1250"/>
 		<Sensor black="0" white="64948"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 5D Mark II" mode="sRaw2">
+		<ID make="Canon" model="EOS 5D Mark II">Canon EOS 5D Mark II</ID>
 		<Crop x="0" y="0" width="2808" height="1872"/>
 		<Sensor black="0" white="57200" iso_list="160 320 640 1250"/>
 		<Sensor black="0" white="64948"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 5D Mark III" decoder_version="2">
+		<ID make="Canon" model="EOS 5D Mark III">Canon EOS 5D Mark III</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -500,6 +539,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 5D Mark III" mode="sRaw1">
+		<ID make="Canon" model="EOS 5D Mark III">Canon EOS 5D Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="44112" iso_list="160 320 640 1250 2500 5000 10000"/>
 		<Sensor black="0" white="50300" iso_list="100 20000"/>
@@ -511,6 +551,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 5D Mark III" mode="sRaw2">
+		<ID make="Canon" model="EOS 5D Mark III">Canon EOS 5D Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="44112" iso_list="160 320 640 1250 2500 5000 10000"/>
 		<Sensor black="0" white="51300" iso_list="250"/>
@@ -522,6 +563,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 5DS R" decoder_version="6">
+		<ID make="Canon" model="EOS 5DS R">Canon EOS 5DS R</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -536,6 +578,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 6D" decoder_version="2">
+		<ID make="Canon" model="EOS 6D">Canon EOS 6D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -551,6 +594,7 @@
 	</Camera>
 	<!---Guess -->
 	<Camera make="Canon" model="Canon EOS 6D" mode="sRaw1" decoder_version="3">
+		<ID make="Canon" model="EOS 6D">Canon EOS 6D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="48664"/>
 		<Hints>
@@ -560,6 +604,7 @@
 	</Camera>
 	<!---Guess -->
 	<Camera make="Canon" model="Canon EOS 6D" mode="sRaw2">
+		<ID make="Canon" model="EOS 6D">Canon EOS 6D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="48664"/>
 		<Hints>
@@ -568,6 +613,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 7D" decoder_version="1">
+		<ID make="Canon" model="EOS 7D">Canon EOS 7D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -583,16 +629,19 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 7D" mode="sRaw1">
+		<ID make="Canon" model="EOS 7D">Canon EOS 7D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="44200" iso_list="100 125 160 320 640 1250"/>
 		<Sensor black="0" white="54000"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 7D" mode="sRaw2">
+		<ID make="Canon" model="EOS 7D">Canon EOS 7D</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="44200" iso_list="100 125 160 320 640 1250"/>
 		<Sensor black="0" white="54000"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 7D Mark II">
+		<ID make="Canon" model="EOS 7D Mark II">Canon EOS 7D Mark II</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -608,6 +657,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 7D Mark II" mode="sRaw1">
+		<ID make="Canon" model="EOS 7D Mark II">Canon EOS 7D Mark II</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 		<Hints>
@@ -616,6 +666,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 7D Mark II" mode="sRaw2">
+		<ID make="Canon" model="EOS 7D Mark II">Canon EOS 7D Mark II</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 		<Hints>
@@ -624,6 +675,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 1000D">
+		<ID make="Canon" model="EOS 1000D">Canon EOS 1000D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -638,11 +690,12 @@
 			<Horizontal y="2" height="14"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS DIGITAL REBEL XS</Alias>
-			<Alias>Canon EOS Kiss Digital F</Alias>
+			<Alias id="EOS Digital Rebel XS">Canon EOS DIGITAL REBEL XS</Alias>
+			<Alias id="EOS Kiss Digital F">Canon EOS Kiss Digital F</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 1100D">
+		<ID make="Canon" model="EOS 1100D">Canon EOS 1100D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -656,10 +709,11 @@
 			<Horizontal y="4" height="12"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS REBEL T3</Alias>
+			<Alias id="EOS Rebel T3">Canon EOS REBEL T3</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 1200D">
+		<ID make="Canon" model="EOS 1200D">Canon EOS 1200D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -674,11 +728,12 @@
 			<Horizontal y="4" height="44"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS REBEL T5</Alias>
-			<Alias>Canon EOS Kiss X70</Alias>
+			<Alias id="EOS Rebel T5">Canon EOS REBEL T5</Alias>
+			<Alias id="EOS Kiss X70">Canon EOS Kiss X70</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 400D DIGITAL">
+		<ID make="Canon" model="EOS 400D">Canon EOS 400D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -692,11 +747,12 @@
 			<Horizontal y="4" height="12"/>
 		</BlackAreas>
 		<Aliases>
-			<Alias>Canon EOS DIGITAL REBEL XTi</Alias>
-			<Alias>Canon EOS Kiss Digital X</Alias>
+			<Alias id="EOS Digital Rebel XTi">Canon EOS DIGITAL REBEL XTi</Alias>
+			<Alias id="EOS Kiss Digital X">Canon EOS Kiss Digital X</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS M">
+		<ID make="Canon" model="EOS M">Canon EOS M</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -712,6 +768,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS M2">
+		<ID make="Canon" model="EOS M2">Canon EOS M2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -727,6 +784,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D" decoder_version="5">
+		<ID make="Canon" model="EOS-1D">Canon EOS-1D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -741,6 +799,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1DS" decoder_version="5">
+		<ID make="Canon" model="EOS-1Ds">Canon EOS-1Ds</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -769,6 +828,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark II">
+		<ID make="Canon" model="EOS-1D Mark II">Canon EOS-1D Mark II</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -786,6 +846,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark II N">
+		<ID make="Canon" model="EOS-1D Mark II N">Canon EOS-1D Mark II N</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -800,6 +861,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark III" decoder_version="1">
+		<ID make="Canon" model="EOS-1D Mark III">Canon EOS-1D Mark III</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -814,14 +876,17 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark III" mode="sRaw1">
+		<ID make="Canon" model="EOS-1D Mark III">Canon EOS-1D Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark III" mode="sRaw2">
+		<ID make="Canon" model="EOS-1D Mark III">Canon EOS-1D Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark IV" decoder_version="1">
+		<ID make="Canon" model="EOS-1D Mark IV">Canon EOS-1D Mark IV</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -836,14 +901,17 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark IV" mode="sRaw1">
+		<ID make="Canon" model="EOS-1D Mark IV">Canon EOS-1D Mark IV</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark IV" mode="sRaw2">
+		<ID make="Canon" model="EOS-1D Mark IV">Canon EOS-1D Mark IV</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1Ds Mark II">
+		<ID make="Canon" model="EOS-1Ds Mark II">Canon EOS-1Ds Mark II</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -861,6 +929,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1Ds Mark III" decoder_version="1">
+		<ID make="Canon" model="EOS-1Ds Mark III">Canon EOS-1Ds Mark III</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -875,14 +944,17 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1Ds Mark III" mode="sRaw1">
+		<ID make="Canon" model="EOS-1Ds Mark III">Canon EOS-1Ds Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1Ds Mark III" mode="sRaw2">
+		<ID make="Canon" model="EOS-1Ds Mark III">Canon EOS-1Ds Mark III</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D X" decoder_version="1">
+		<ID make="Canon" model="EOS-1D X">Canon EOS-1D X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -897,6 +969,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D X" mode="sRaw1">
+		<ID make="Canon" model="EOS-1D X">Canon EOS-1D X</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 		<Hints>
@@ -905,6 +978,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D X" mode="sRaw2">
+		<ID make="Canon" model="EOS-1D X">Canon EOS-1D X</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 		<Hints>
@@ -913,6 +987,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot Pro1">
+		<ID make="Canon" model="PowerShot Pro1">Canon PowerShot Pro1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -929,8 +1004,10 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot Pro70" supported="no">
+		<ID make="Canon" model="PowerShot Pro70">Canon PowerShot Pro70</ID>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G1">
+		<ID make="Canon" model="PowerShot G1">Canon PowerShot G1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -947,6 +1024,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G2">
+		<ID make="Canon" model="PowerShot G2">Canon PowerShot G2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -964,6 +1042,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G3">
+		<ID make="Canon" model="PowerShot G3">Canon PowerShot G3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -981,6 +1060,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G5">
+		<ID make="Canon" model="PowerShot G5">Canon PowerShot G5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -998,6 +1078,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G6">
+		<ID make="Canon" model="PowerShot G6">Canon PowerShot G6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1015,6 +1096,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G7 X">
+		<ID make="Canon" model="PowerShot G7 X">Canon PowerShot G7 X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1028,6 +1110,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G1 X">
+		<ID make="Canon" model="PowerShot G1 X">Canon PowerShot G1 X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1045,6 +1128,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G1 X Mark II">
+		<ID make="Canon" model="PowerShot G1 X Mark II">Canon PowerShot G1 X Mark II</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1059,6 +1143,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G12">
+		<ID make="Canon" model="PowerShot G12">Canon PowerShot G12</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1076,6 +1161,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G11">
+		<ID make="Canon" model="PowerShot G11">Canon PowerShot G11</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1095,6 +1181,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G10">
+		<ID make="Canon" model="PowerShot G10">Canon PowerShot G10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1112,6 +1199,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G9">
+		<ID make="Canon" model="PowerShot G9">Canon PowerShot G9</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1126,6 +1214,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G15">
+		<ID make="Canon" model="PowerShot G15">Canon PowerShot G15</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1141,6 +1230,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot G16" decoder_version="4">
+		<ID make="Canon" model="PowerShot G16">Canon PowerShot G16</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1155,6 +1245,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot SX1 IS">
+		<ID make="Canon" model="PowerShot SX1 IS">Canon PowerShot SX1 IS</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1172,6 +1263,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S30">
+		<ID make="Canon" model="PowerShot S30">Canon PowerShot S30</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1188,6 +1280,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S40">
+		<ID make="Canon" model="PowerShot S40">Canon PowerShot S40</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1205,6 +1298,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S45">
+		<ID make="Canon" model="PowerShot S45">Canon PowerShot S45</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1221,6 +1315,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S50">
+		<ID make="Canon" model="PowerShot S50">Canon PowerShot S50</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1238,6 +1333,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S60">
+		<ID make="Canon" model="PowerShot S60">Canon PowerShot S60</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1255,6 +1351,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S70">
+		<ID make="Canon" model="PowerShot S70">Canon PowerShot S70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1272,6 +1369,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S90">
+		<ID make="Canon" model="PowerShot S90">Canon PowerShot S90</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1286,6 +1384,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S95">
+		<ID make="Canon" model="PowerShot S95">Canon PowerShot S95</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1302,6 +1401,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S100">
+		<ID make="Canon" model="PowerShot S100">Canon PowerShot S100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1317,6 +1417,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S110">
+		<ID make="Canon" model="PowerShot S110">Canon PowerShot S110</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1332,6 +1433,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot S120">
+		<ID make="Canon" model="PowerShot S120">Canon PowerShot S120</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1349,6 +1451,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="Canon" model="Canon PowerShot SX50 HS">
+		<ID make="Canon" model="PowerShot SX50 HS">Canon PowerShot SX50 HS</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1366,6 +1469,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D100">
+		<ID make="Nikon" model="D100">Nikon D100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -1376,6 +1480,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D1">
+		<ID make="Nikon" model="D1">Nikon D1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1389,6 +1494,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D1H">
+		<ID make="Nikon" model="D1H">Nikon D1H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1399,6 +1505,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D1X">
+		<ID make="Nikon" model="D1X">Nikon D1X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1412,6 +1519,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D200">
+		<ID make="Nikon" model="D200">Nikon D200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -1422,6 +1530,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D2H">
+		<ID make="Nikon" model="D2H">Nikon D2H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1432,6 +1541,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D2Hs">
+		<ID make="Nikon" model="D2Hs">Nikon D2Hs</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1442,6 +1552,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D2X">
+		<ID make="Nikon" model="D2X">Nikon D2X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1452,6 +1563,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3">
+		<ID make="Nikon" model="D3">Nikon D3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1462,6 +1574,7 @@
 		<Sensor black="0" white="16384"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3S">
+		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1472,6 +1585,7 @@
 		<Sensor black="0" white="16384"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3X">
+		<ID make="Nikon" model="D3X">Nikon D3X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1482,6 +1596,7 @@
 		<Sensor black="0" white="16384"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D300">
+		<ID make="Nikon" model="D300">Nikon D300</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1492,6 +1607,7 @@
 		<Sensor black="0" white="15236"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D300S">
+		<ID make="Nikon" model="D300S">Nikon D300S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1502,6 +1618,7 @@
 		<Sensor black="0" white="15236"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3000">
+		<ID make="Nikon" model="D3000">Nikon D3000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1512,6 +1629,7 @@
 		<Sensor black="0" white="16383"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3200">
+		<ID make="Nikon" model="D3200">Nikon D3200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1522,6 +1640,7 @@
 		<Sensor black="0" white="16383"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3300">
+		<ID make="Nikon" model="D3300">Nikon D3300</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1535,6 +1654,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4">
+		<ID make="Nikon" model="D4">Nikon D4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1548,6 +1668,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON Df">
+		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1561,6 +1682,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5100"  decoder_version="2">
+		<ID make="Nikon" model="D5100">Nikon D5100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1571,6 +1693,7 @@
 		<Sensor black="0" white="15892"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3100"  decoder_version="2">
+		<ID make="Nikon" model="D3100">Nikon D3100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1581,6 +1704,7 @@
 		<Sensor black="0" white="16383"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D40">
+		<ID make="Nikon" model="D40">Nikon D40</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1591,6 +1715,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D40X">
+		<ID make="Nikon" model="D40X">Nikon D40X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1601,6 +1726,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D50">
+		<ID make="Nikon" model="D50">Nikon D50</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1611,6 +1737,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5000">
+		<ID make="Nikon" model="D5000">Nikon D5000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1621,6 +1748,7 @@
 		<Sensor black="0" white="4096"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5200">
+		<ID make="Nikon" model="D5200">Nikon D5200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1631,6 +1759,7 @@
 		<Sensor black="0" white="4096"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5300" mode="12bit-compressed">
+		<ID make="Nikon" model="D5300">Nikon D5300</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1644,6 +1773,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5300">
+		<ID make="Nikon" model="D5300">Nikon D5300</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1657,6 +1787,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5500" mode="12bit-compressed">
+		<ID make="Nikon" model="D5500">Nikon D5500</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1670,6 +1801,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5500">
+		<ID make="Nikon" model="D5500">Nikon D5500</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1683,6 +1815,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D60">
+		<ID make="Nikon" model="D60">Nikon D60</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1693,6 +1826,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D600">
+		<ID make="Nikon" model="D600">Nikon D600</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1703,6 +1837,7 @@
 		<Sensor black="0" white="16383"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D610">
+		<ID make="Nikon" model="D610">Nikon D610</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1713,6 +1848,7 @@
 		<Sensor black="0" white="16383"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D70">
+		<ID make="Nikon" model="D70">Nikon D70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1723,6 +1859,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D700">
+		<ID make="Nikon" model="D700">Nikon D700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1733,6 +1870,7 @@
 		<Sensor black="0" white="3972"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-uncompressed">
+		<ID make="Nikon" model="D700">Nikon D700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1743,6 +1881,7 @@
 		<Sensor black="0" white="16383"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="12bit-compressed">
+		<ID make="Nikon" model="D750">Nikon D750</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1756,6 +1895,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="14bit-compressed">
+		<ID make="Nikon" model="D750">Nikon D750</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1769,6 +1909,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7000">
+		<ID make="Nikon" model="D7000">Nikon D7000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1779,6 +1920,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7100">
+		<ID make="Nikon" model="D7100">Nikon D7100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1788,7 +1930,8 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="16383"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D7200">
+	<Camera make="NIKON CORPORATION" model="NIKON D7200" mode="14bit-compressed">
+		<ID make="Nikon" model="D7200">Nikon D7200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1801,7 +1944,22 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D7200" mode="12bit-compressed">
+		<ID make="Nikon" model="D7200">Nikon D7200</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="150" white="3972"/>
+		<Hints>
+			<Hint name="nikon_override_auto_black" value=""/>
+		</Hints>
+	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D70s">
+		<ID make="Nikon" model="D70s">Nikon D70s</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1812,6 +1970,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D80">
+		<ID make="Nikon" model="D80">Nikon D80</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1822,6 +1981,7 @@
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D800" mode="7424x4924-14bit-uncompressed">
+		<ID make="Nikon" model="D800">Nikon D800</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1830,11 +1990,9 @@
 		</CFA>
 		<Crop x="2" y="0" width="-48" height="0"/>
 		<Sensor black="0" white="15520"/>
-		<Aliases>
-			<Alias>NIKON D800E</Alias>
-		</Aliases>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D800" mode="14bit-uncompressed">
+		<ID make="Nikon" model="D800">Nikon D800</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1843,11 +2001,9 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15520"/>
-		<Aliases>
-			<Alias>NIKON D800E</Alias>
-		</Aliases>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D800">
+		<ID make="Nikon" model="D800">Nikon D800</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1856,15 +2012,47 @@
 		</CFA>
 		<Crop x="2" y="0" width="-48" height="0"/>
 		<Sensor black="0" white="3880"/>
-		<Aliases>
-			<Alias>NIKON D800E</Alias>
-		</Aliases>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D800E" mode="7424x4924-14bit-uncompressed">
+		<ID make="Nikon" model="D800E">Nikon D800E</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="2" y="0" width="-48" height="0"/>
+		<Sensor black="0" white="15520"/>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D800E" mode="14bit-uncompressed">
+		<ID make="Nikon" model="D800E">Nikon D800E</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="15520"/>
+	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D800E">
+		<ID make="Nikon" model="D800E">Nikon D800E</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="2" y="0" width="-48" height="0"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="sNEF-uncompressed">
+		<ID make="Nikon" model="D810">Nikon D810</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="12bit-uncompressed">
+		<ID make="Nikon" model="D810">Nikon D810</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1879,6 +2067,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="12bit-compressed">
+		<ID make="Nikon" model="D810">Nikon D810</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1892,6 +2081,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="14bit-uncompressed">
+		<ID make="Nikon" model="D810">Nikon D810</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1906,6 +2096,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="14bit-compressed">
+		<ID make="Nikon" model="D810">Nikon D810</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1919,10 +2110,12 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S" mode="sNEF-uncompressed">
+		<ID make="Nikon" model="D4S">Nikon D4S</ID>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S" mode="12bit-compressed">
+		<ID make="Nikon" model="D4S">Nikon D4S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1936,6 +2129,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S" mode="12bit-uncompressed">
+		<ID make="Nikon" model="D4S">Nikon D4S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1950,6 +2144,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S" mode="14bit-uncompressed">
+		<ID make="Nikon" model="D4S">Nikon D4S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1964,6 +2159,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S">
+		<ID make="Nikon" model="D4S">Nikon D4S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1977,6 +2173,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D90">
+		<ID make="Nikon" model="D90">Nikon D90</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -1987,6 +2184,7 @@
 		<Sensor black="0" white="3767"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J1" decoder_version="4">
+		<ID make="Nikon" model="1 J1">Nikon 1 J1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -1997,6 +2195,7 @@
 		<Sensor black="0" white="0"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J2" decoder_version="4">
+		<ID make="Nikon" model="1 J2">Nikon 1 J2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2007,6 +2206,7 @@
 		<Sensor black="0" white="0"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" decoder_version="4">
+		<ID make="Nikon" model="1 J3">Nikon 1 J3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2017,6 +2217,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" decoder_version="4">
+		<ID make="Nikon" model="1 J4">Nikon 1 J4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2030,6 +2231,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 S1" decoder_version="4">
+		<ID make="Nikon" model="1 S1">Nikon 1 S1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2040,6 +2242,7 @@
 		<Sensor black="0" white="0"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" decoder_version="4">
+		<ID make="Nikon" model="1 S2">Nikon 1 S2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2053,6 +2256,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 V1" decoder_version="4">
+		<ID make="Nikon" model="1 V1">Nikon 1 V1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2063,6 +2267,7 @@
 		<Sensor black="0" white="0"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" decoder_version="4">
+		<ID make="Nikon" model="1 V2">Nikon 1 V2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2073,6 +2278,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" decoder_version="4">
+		<ID make="Nikon" model="1 AW1">Nikon 1 AW1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2083,6 +2289,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON" model="E5400" decoder_version="3">
+		<ID make="Nikon" model="E5400">Nikon E5400</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2096,6 +2303,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON" model="E5700" decoder_version="4">
+		<ID make="Nikon" model="E5700">Nikon E5700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2109,6 +2317,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON" model="E8400" decoder_version="3">
+		<ID make="Nikon" model="E8400">Nikon E8400</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2122,6 +2331,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON" model="COOLPIX P330" decoder_version="5">
+		<ID make="Nikon" model="Coolpix P330">Nikon Coolpix P330</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2135,7 +2345,19 @@
 			<Hint name="real_bpp" value="16"/>
 		</Hints>
 	</Camera>
+	<Camera make="NIKON" model="COOLPIX P340" decoder_version="5">
+		<ID make="Nikon" model="Coolpix P340">Nikon Coolpix P340</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="200" white="3800"/>
+	</Camera>
 	<Camera make="NIKON CORPORATION" model="COOLPIX A">
+		<ID make="Nikon" model="Coolpix A">Nikon Coolpix A</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2146,6 +2368,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON" model="COOLPIX P6000" decoder_version="1">
+		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2160,6 +2383,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON" model="COOLPIX P7000" decoder_version="1">
+		<ID make="Nikon" model="Coolpix P7000">Nikon Coolpix P7000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2176,6 +2400,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON" model="COOLPIX P7100" decoder_version="1">
+		<ID make="Nikon" model="Coolpix P7100">Nikon Coolpix P7100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2192,6 +2417,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON" model="COOLPIX P7700" decoder_version="5">
+		<ID make="Nikon" model="Coolpix P7700">Nikon Coolpix P7700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2206,6 +2432,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON" model="COOLPIX P7800" decoder_version="5">
+		<ID make="Nikon" model="Coolpix P7800">Nikon Coolpix P7800</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2220,6 +2447,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="NIKON" model="E8800" decoder_version="3">
+		<ID make="Nikon" model="Coolpix E8800">Nikon Coolpix E8800</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2233,6 +2461,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS OPTICAL CO.,LTD" model="C5050Z">
+		<ID make="Olympus" model="C5050Z">Olympus C5050Z</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2243,6 +2472,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS CORPORATION" model="C5060WZ">
+		<ID make="Olympus" model="C5060WZ">Olympus C5060WZ</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2253,6 +2483,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS CORPORATION" model="C8080WZ">
+		<ID make="Olympus" model="C8080WZ">Olympus C8080WZ</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2263,6 +2494,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS CORPORATION" model="E-1">
+		<ID make="Olympus" model="E-1">Olympus E-1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -2273,6 +2505,7 @@
 		<Sensor black="65" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="C7070WZ">
+		<ID make="Olympus" model="C7070WZ">Olympus C7070WZ</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2283,6 +2516,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-3">
+		<ID make="Olympus" model="E-3">Olympus E-3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2293,6 +2527,7 @@
 		<Sensor black="65" white="4015"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-30">
+		<ID make="Olympus" model="E-30">Olympus E-30</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2303,6 +2538,7 @@
 		<Sensor black="65" white="4015"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-300" decoder_version="3">
+		<ID make="Olympus" model="E-300">Olympus E-300</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2317,6 +2553,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-330" decoder_version="3">
+		<ID make="Olympus" model="E-330">Olympus E-330</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2331,6 +2568,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-400">
+		<ID make="Olympus" model="E-400">Olympus E-400</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -2341,6 +2579,7 @@
 		<Sensor black="96" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-410">
+		<ID make="Olympus" model="E-410">Olympus E-410</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2351,6 +2590,7 @@
 		<Sensor black="72" white="3500"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-420">
+		<ID make="Olympus" model="E-420">Olympus E-420</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2361,6 +2601,7 @@
 		<Sensor black="68" white="4015"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-450">
+		<ID make="Olympus" model="E-450">Olympus E-450</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2371,6 +2612,7 @@
 		<Sensor black="69" white="4015"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-500" decoder_version="3">
+		<ID make="Olympus" model="E-500">Olympus E-500</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2385,6 +2627,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-510">
+		<ID make="Olympus" model="E-510">Olympus E-510</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2395,6 +2638,7 @@
 		<Sensor black="72" white="3500"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-520">
+		<ID make="Olympus" model="E-520">Olympus E-520</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2405,6 +2649,7 @@
 		<Sensor black="69" white="4015"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-600">
+		<ID make="Olympus" model="E-600">Olympus E-600</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2415,6 +2660,7 @@
 		<Sensor black="64" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-620">
+		<ID make="Olympus" model="E-620">Olympus E-620</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2425,6 +2671,7 @@
 		<Sensor black="64" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="SP350">
+		<ID make="Olympus" model="SP350">Olympus SP350</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2435,6 +2682,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="SP500UZ">
+		<ID make="Olympus" model="SP500UZ">Olympus SP500UZ</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2445,6 +2693,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-5">
+		<ID make="Olympus" model="E-5">Olympus E-5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2455,6 +2704,7 @@
 		<Sensor black="80" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS OPTICAL CO.,LTD" model="E-10">
+		<ID make="Olympus" model="E-10">Olympus E-10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2465,6 +2715,7 @@
 		<Sensor black="32" white="1023"/>
 	</Camera>
 	<Camera make="OLYMPUS OPTICAL CO.,LTD" model="E-20,E-20N,E-20P">
+		<ID make="Olympus" model="E-20">Olympus E-20</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2475,6 +2726,7 @@
 		<Sensor black="0" white="4092"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-M1">
+		<ID make="Olympus" model="E-M1">Olympus E-M1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2485,6 +2737,7 @@
 		<Sensor black="255" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-M10">
+		<ID make="Olympus" model="E-M10">Olympus E-M10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2495,6 +2748,7 @@
 		<Sensor black="254" white="4000"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-M5">
+		<ID make="Olympus" model="E-M5">Olympus E-M5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2505,6 +2759,7 @@
 		<Sensor black="255" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-M5MarkII">
+		<ID make="Olympus" model="E-M5 Mark II">Olympus E-M5 Mark II</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2520,6 +2775,7 @@
 		<Sensor black="187" white="4000" iso_min="25600" iso_max="25600"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-P1">
+		<ID make="Olympus" model="E-P1">Olympus E-P1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2530,6 +2786,7 @@
 		<Sensor black="55" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-PL1">
+		<ID make="Olympus" model="E-PL1">Olympus E-PL1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2540,6 +2797,7 @@
 		<Sensor black="55" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-PL2">
+		<ID make="Olympus" model="E-PL2">Olympus E-PL2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2553,6 +2811,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-PL3">
+		<ID make="Olympus" model="E-PL3">Olympus E-PL3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2566,6 +2825,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-PL5">
+		<ID make="Olympus" model="E-PL5">Olympus E-PL5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2576,6 +2836,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-PL6">
+		<ID make="Olympus" model="E-PL6">Olympus E-PL6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2586,6 +2847,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-PL7">
+		<ID make="Olympus" model="E-PL7">Olympus E-PL7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2596,6 +2858,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-P5">
+		<ID make="Olympus" model="E-P5">Olympus E-P5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2606,6 +2869,7 @@
 		<Sensor black="250" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-PM1">
+		<ID make="Olympus" model="E-PM1">Olympus E-PM1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2619,6 +2883,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-PM2">
+		<ID make="Olympus" model="E-PM2">Olympus E-PM2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2629,6 +2894,7 @@
 		<Sensor black="250" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-P2">
+		<ID make="Olympus" model="E-P2">Olympus E-P2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2639,6 +2905,7 @@
 		<Sensor black="55" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="E-P3">
+		<ID make="Olympus" model="E-P3">Olympus E-P3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2649,6 +2916,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="XZ-1">
+		<ID make="Olympus" model="XZ-1">Olympus XZ-1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2659,6 +2927,7 @@
 		<Sensor black="55" white="3972"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="XZ-2" decoder_version="3">
+		<ID make="Olympus" model="XZ-2">Olympus XZ-2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2673,6 +2942,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="XZ-10" decoder_version="3">
+		<ID make="Olympus" model="XZ-10">Olympus XZ-10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2687,6 +2957,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="SP570UZ">
+		<ID make="Olympus" model="SP570UZ">Olympus SP570UZ</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -2697,6 +2968,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="OLYMPUS IMAGING CORP." model="STYLUS1">
+		<ID make="Olympus" model="Stylus1">Olympus Stylus1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2706,10 +2978,11 @@
 		<Crop x="0" y="0" width="-14" height="0"/>
 		<Sensor black="200" white="3900"/>
 		<Aliases>
-			<Alias>STYLUS1,1s</Alias>
+			<Alias id="Stylus1">STYLUS1,1s</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-CM1">
+		<ID make="Panasonic" model="DMC-CM1">Panasonic DMC-CM1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2723,6 +2996,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-CM1" mode="3:2">
+		<ID make="Panasonic" model="DMC-CM1">Panasonic DMC-CM1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2736,6 +3010,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FX150">
+		<ID make="Panasonic" model="DMC-FX150">Panasonic DMC-FX150</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2749,6 +3024,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FX150" mode = "4:3">
+		<ID make="Panasonic" model="DMC-FX150">Panasonic DMC-FX150</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2762,6 +3038,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ28" mode = "4:3">
+		<ID make="Panasonic" model="DMC-FZ28">Panasonic DMC-FZ28</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2775,6 +3052,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ28" mode = "16:9">
+		<ID make="Panasonic" model="DMC-FZ28">Panasonic DMC-FZ28</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2788,6 +3066,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ28">
+		<ID make="Panasonic" model="DMC-FZ28">Panasonic DMC-FZ28</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -2801,6 +3080,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ150">
+		<ID make="Panasonic" model="DMC-FZ150">Panasonic DMC-FZ150</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2814,6 +3094,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ150" mode="4:3">
+		<ID make="Panasonic" model="DMC-FZ150">Panasonic DMC-FZ150</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2827,6 +3108,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ200">
+		<ID make="Panasonic" model="DMC-FZ200">Panasonic DMC-FZ200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2840,6 +3122,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ200" mode="4:3">
+		<ID make="Panasonic" model="DMC-FZ200">Panasonic DMC-FZ200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2852,7 +3135,50 @@
 			<Hint name="zero_is_bad" value=""/>
 		</Hints>
 	</Camera>
+	<Camera make="Panasonic" model = "DMC-FZ200" mode="3:2">
+		<ID make="Panasonic" model="DMC-FZ200">Panasonic DMC-FZ200</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-128" height="0"/>
+		<Sensor black="150" white="3956"/>
+		<Hints>
+			<Hint name="zero_is_bad" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="Panasonic" model = "DMC-FZ200" mode="1:1">
+		<ID make="Panasonic" model="DMC-FZ200">Panasonic DMC-FZ200</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-16" height="0"/>
+		<Sensor black="150" white="3956"/>
+		<Hints>
+			<Hint name="zero_is_bad" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="Panasonic" model = "DMC-FZ200" mode="16:9">
+		<ID make="Panasonic" model="DMC-FZ200">Panasonic DMC-FZ200</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-128" height="0"/>
+		<Sensor black="150" white="3956"/>
+		<Hints>
+			<Hint name="zero_is_bad" value=""/>
+		</Hints>
+	</Camera>
 	<Camera make="Panasonic" model = "DMC-G1">
+		<ID make="Panasonic" model="DMC-G1">Panasonic DMC-G1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2866,6 +3192,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G1" mode="4:3">
+		<ID make="Panasonic" model="DMC-G1">Panasonic DMC-G1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2879,6 +3206,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G1" mode="16:9">
+		<ID make="Panasonic" model="DMC-G1">Panasonic DMC-G1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2892,6 +3220,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G1" mode="3:2">
+		<ID make="Panasonic" model="DMC-G1">Panasonic DMC-G1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2905,6 +3234,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G2" mode="4:3">
+		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2918,6 +3248,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G2" mode="3:2">
+		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2931,6 +3262,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G2" mode="16:9">
+		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2944,6 +3276,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G2" mode="1:1">
+		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2957,6 +3290,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G2">
+		<ID make="Panasonic" model="DMC-G2">Panasonic DMC-G2</ID>
 		<!-- Default Guess -->
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -2968,6 +3302,7 @@
 		<Sensor black="0" white="3900"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G10">
+		<ID make="Panasonic" model="DMC-G10">Panasonic DMC-G10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2978,6 +3313,7 @@
 		<Sensor black="0" white="3900"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G10" mode="4:3">
+		<ID make="Panasonic" model="DMC-G10">Panasonic DMC-G10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2988,6 +3324,7 @@
 		<Sensor black="0" white="3900"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH1" mode="4:3">
+		<ID make="Panasonic" model="DMC-GH1">Panasonic DMC-GH1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -2998,6 +3335,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH1" mode="3:2">
+		<ID make="Panasonic" model="DMC-GH1">Panasonic DMC-GH1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3008,6 +3346,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH1">
+		<ID make="Panasonic" model="DMC-GH1">Panasonic DMC-GH1</ID>
 		<!-- Default Guess -->
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -3019,6 +3358,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH3" mode="4:3">
+		<ID make="Panasonic" model="DMC-GH3">Panasonic DMC-GH3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3033,6 +3373,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH3" mode="3:2">
+		<ID make="Panasonic" model="DMC-GH3">Panasonic DMC-GH3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3047,6 +3388,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH3" mode="16:9">
+		<ID make="Panasonic" model="DMC-GH3">Panasonic DMC-GH3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3061,6 +3403,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH3" mode="1:1">
+		<ID make="Panasonic" model="DMC-GH3">Panasonic DMC-GH3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3076,6 +3419,7 @@
 	</Camera>
 	<!-- Default Guess -->
 	<Camera make="Panasonic" model = "DMC-GH3">
+		<ID make="Panasonic" model="DMC-GH3">Panasonic DMC-GH3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3090,6 +3434,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH4" mode="4:3">
+		<ID make="Panasonic" model="DMC-GH4">Panasonic DMC-GH4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3103,6 +3448,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH4" mode="3:2">
+		<ID make="Panasonic" model="DMC-GH4">Panasonic DMC-GH4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3116,6 +3462,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH4" mode="16:9">
+		<ID make="Panasonic" model="DMC-GH4">Panasonic DMC-GH4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3129,6 +3476,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH4" mode="1:1">
+		<ID make="Panasonic" model="DMC-GH4">Panasonic DMC-GH4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3143,6 +3491,7 @@
 	</Camera>
 	<!-- Default Guess -->
 	<Camera make="Panasonic" model = "DMC-GH4">
+		<ID make="Panasonic" model="DMC-GH4">Panasonic DMC-GH4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3156,6 +3505,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF1">
+		<ID make="Panasonic" model="DMC-GF1">Panasonic DMC-GF1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3169,6 +3519,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF1" mode="4:3">
+		<ID make="Panasonic" model="DMC-GF1">Panasonic DMC-GF1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3182,6 +3533,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF1" mode="16:9">
+		<ID make="Panasonic" model="DMC-GF1">Panasonic DMC-GF1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3195,6 +3547,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF1" mode="3:2">
+		<ID make="Panasonic" model="DMC-GF1">Panasonic DMC-GF1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3208,6 +3561,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF1" mode="1:1">
+		<ID make="Panasonic" model="DMC-GF1">Panasonic DMC-GF1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3221,6 +3575,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF2">
+		<ID make="Panasonic" model="DMC-GF2">Panasonic DMC-GF2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3234,6 +3589,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF2" mode="4:3">
+		<ID make="Panasonic" model="DMC-GF2">Panasonic DMC-GF2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3247,6 +3603,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF2" mode="16:9">
+		<ID make="Panasonic" model="DMC-GF2">Panasonic DMC-GF2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3260,6 +3617,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF2" mode="3:2">
+		<ID make="Panasonic" model="DMC-GF2">Panasonic DMC-GF2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3273,6 +3631,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF2" mode="1:1">
+		<ID make="Panasonic" model="DMC-GF2">Panasonic DMC-GF2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3283,6 +3642,7 @@
 		<Sensor black="150" white="3956"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GM1" mode="4:3">
+		<ID make="Panasonic" model="DMC-GM1">Panasonic DMC-GM1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3296,6 +3656,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GM1" mode="3:2">
+		<ID make="Panasonic" model="DMC-GM1">Panasonic DMC-GM1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3309,6 +3670,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GM1" mode="16:9">
+		<ID make="Panasonic" model="DMC-GM1">Panasonic DMC-GM1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3322,6 +3684,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GM1" mode="1:1">
+		<ID make="Panasonic" model="DMC-GM1">Panasonic DMC-GM1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3336,6 +3699,7 @@
 	</Camera>
 	<!-- Default Guess -->
 	<Camera make="Panasonic" model = "DMC-GM1">
+		<ID make="Panasonic" model="DMC-GM1">Panasonic DMC-GM1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3349,6 +3713,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-GM5">
+		<ID make="Panasonic" model="DMC-GM5">Panasonic DMC-GM5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3359,6 +3724,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-GM5" mode="4:3">
+		<ID make="Panasonic" model="DMC-GM5">Panasonic DMC-GM5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3369,6 +3735,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-GM5" mode="3:2">
+		<ID make="Panasonic" model="DMC-GM5">Panasonic DMC-GM5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3379,6 +3746,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-GM5" mode="16:9">
+		<ID make="Panasonic" model="DMC-GM5">Panasonic DMC-GM5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3389,6 +3757,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-GM5" mode="1:1">
+		<ID make="Panasonic" model="DMC-GM5">Panasonic DMC-GM5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3399,6 +3768,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-G3" mode="4:3">
+		<ID make="Panasonic" model="DMC-G3">Panasonic DMC-G3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -3412,6 +3782,7 @@
 		<Sensor black="143" white="3956"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-G3" mode="1:1">
+		<ID make="Panasonic" model="DMC-G3">Panasonic DMC-G3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -3425,6 +3796,7 @@
 		<Sensor black="143" white="3956"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-G3" mode="16:9">
+		<ID make="Panasonic" model="DMC-G3">Panasonic DMC-G3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -3438,6 +3810,7 @@
 		<Sensor black="143" white="3956"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-G3" mode="3:2">
+		<ID make="Panasonic" model="DMC-G3">Panasonic DMC-G3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -3451,6 +3824,7 @@
 		<Sensor black="143" white="3956"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-G3">
+		<ID make="Panasonic" model="DMC-G3">Panasonic DMC-G3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -3464,45 +3838,75 @@
 		<Sensor black="143" white="3956"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G5" mode="4:3">
+		<ID make="Panasonic" model="DMC-G5">Panasonic DMC-G5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">RED</Color>
 		</CFA>
-		<Crop x="0" y="0" width="-194" height="0"/>
+		<Crop x="0" y="0" width="-192" height="0"/>
 		<Sensor black="150" white="3956"/>
 		<Hints>
 			<Hint name="zero_is_bad" value=""/>
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G5" mode="3:2">
+		<ID make="Panasonic" model="DMC-G5">Panasonic DMC-G5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">RED</Color>
 		</CFA>
-		<Crop x="0" y="0" width="-194" height="0"/>
+		<Crop x="0" y="0" width="-192" height="0"/>
+		<Sensor black="150" white="3956"/>
+		<Hints>
+			<Hint name="zero_is_bad" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="Panasonic" model = "DMC-G5" mode="16:9">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-192" height="0"/>
+		<Sensor black="150" white="3956"/>
+		<Hints>
+			<Hint name="zero_is_bad" value=""/>
+		</Hints>
+	</Camera>
+	<Camera make="Panasonic" model = "DMC-G5" mode="1:1">
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3956"/>
 		<Hints>
 			<Hint name="zero_is_bad" value=""/>
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G5">
+		<ID make="Panasonic" model="DMC-G5">Panasonic DMC-G5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">RED</Color>
 		</CFA>
-		<Crop x="0" y="0" width="-194" height="0"/>
+		<Crop x="0" y="0" width="-192" height="0"/>
 		<Sensor black="150" white="3956"/>
 		<Hints>
 			<Hint name="zero_is_bad" value=""/>
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G6">
+		<ID make="Panasonic" model="DMC-G6">Panasonic DMC-G6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3516,6 +3920,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G6" mode="4:3">
+		<ID make="Panasonic" model="DMC-G6">Panasonic DMC-G6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3529,6 +3934,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G6" mode="3:2">
+		<ID make="Panasonic" model="DMC-G6">Panasonic DMC-G6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3542,6 +3948,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G6" mode="16:9">
+		<ID make="Panasonic" model="DMC-G6">Panasonic DMC-G6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3555,6 +3962,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-G6" mode="1:1">
+		<ID make="Panasonic" model="DMC-G6">Panasonic DMC-G6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3568,6 +3976,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF3">
+		<ID make="Panasonic" model="DMC-GF3">Panasonic DMC-GF3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3581,6 +3990,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF3" mode= "4:3">
+		<ID make="Panasonic" model="DMC-GF3">Panasonic DMC-GF3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3594,6 +4004,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF3" mode= "3:2">
+		<ID make="Panasonic" model="DMC-GF3">Panasonic DMC-GF3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3607,6 +4018,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF3" mode= "16:9">
+		<ID make="Panasonic" model="DMC-GF3">Panasonic DMC-GF3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3620,6 +4032,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF3" mode= "1:1">
+		<ID make="Panasonic" model="DMC-GF3">Panasonic DMC-GF3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3633,6 +4046,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF5">
+		<ID make="Panasonic" model="DMC-GF5">Panasonic DMC-GF5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3646,6 +4060,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF5" mode= "4:3">
+		<ID make="Panasonic" model="DMC-GF5">Panasonic DMC-GF5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3659,6 +4074,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF5" mode= "16:9">
+		<ID make="Panasonic" model="DMC-GF5">Panasonic DMC-GF5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3672,6 +4088,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF5" mode= "3:2">
+		<ID make="Panasonic" model="DMC-GF5">Panasonic DMC-GF5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3685,6 +4102,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF5" mode= "1:1">
+		<ID make="Panasonic" model="DMC-GF5">Panasonic DMC-GF5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3698,6 +4116,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF6">
+		<ID make="Panasonic" model="DMC-GF6">Panasonic DMC-GF6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -3711,6 +4130,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF6" mode= "4:3">
+		<ID make="Panasonic" model="DMC-GF6">Panasonic DMC-GF6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -3724,6 +4144,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-GF7">
+		<ID make="Panasonic" model="DMC-GF7">Panasonic DMC-GF7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3737,6 +4158,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-GF7" mode="4:3">
+		<ID make="Panasonic" model="DMC-GF7">Panasonic DMC-GF7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3750,6 +4172,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH2">
+		<ID make="Panasonic" model="DMC-GH2">Panasonic DMC-GH2</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="0">BLUE</Color>
@@ -3763,6 +4186,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH2" mode="4:3">
+		<ID make="Panasonic" model="DMC-GH2">Panasonic DMC-GH2</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="0">BLUE</Color>
@@ -3776,6 +4200,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH2" mode="16:9">
+		<ID make="Panasonic" model="DMC-GH2">Panasonic DMC-GH2</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="0">BLUE</Color>
@@ -3789,6 +4214,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH2" mode="3:2">
+		<ID make="Panasonic" model="DMC-GH2">Panasonic DMC-GH2</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="0">BLUE</Color>
@@ -3802,6 +4228,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH2" mode="1:1">
+		<ID make="Panasonic" model="DMC-GH2">Panasonic DMC-GH2</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="0">BLUE</Color>
@@ -3815,6 +4242,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GH1" mode="16:9">
+		<ID make="Panasonic" model="DMC-GH1">Panasonic DMC-GH1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3825,6 +4253,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ35" mode="4:3">
+		<ID make="Panasonic" model="DMC-FZ35">Panasonic DMC-FZ35</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3841,6 +4270,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ35">
+		<ID make="Panasonic" model="DMC-FZ35">Panasonic DMC-FZ35</ID>
 		<!-- Default Guess -->
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3890,6 +4320,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ70">
+		<ID make="Panasonic" model="DMC-FZ70">Panasonic DMC-FZ70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3906,6 +4337,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ70" mode="4:3">
+		<ID make="Panasonic" model="DMC-FZ70">Panasonic DMC-FZ70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -3922,6 +4354,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ100">
+		<ID make="Panasonic" model="DMC-FZ100">Panasonic DMC-FZ100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3935,6 +4368,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ100" mode="4:3">
+		<ID make="Panasonic" model="DMC-FZ100">Panasonic DMC-FZ100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3948,6 +4382,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ1000">
+		<ID make="Panasonic" model="DMC-FZ1000">Panasonic DMC-FZ1000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3958,6 +4393,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ1000" mode="3:2">
+		<ID make="Panasonic" model="DMC-FZ1000">Panasonic DMC-FZ1000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3968,6 +4404,7 @@
 		<Sensor black="142" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ1000" mode="1:1">
+		<ID make="Panasonic" model="DMC-FZ1000">Panasonic DMC-FZ1000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3978,6 +4415,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ1000" mode="4:3">
+		<ID make="Panasonic" model="DMC-FZ1000">Panasonic DMC-FZ1000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3988,6 +4426,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ1000" mode="16:9">
+		<ID make="Panasonic" model="DMC-FZ1000">Panasonic DMC-FZ1000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -3998,6 +4437,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX1">
+		<ID make="Panasonic" model="DMC-GX1">Panasonic DMC-GX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4011,6 +4451,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX1" mode = "4:3">
+		<ID make="Panasonic" model="DMC-GX1">Panasonic DMC-GX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4024,6 +4465,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX1" mode = "3:2">
+		<ID make="Panasonic" model="DMC-GX1">Panasonic DMC-GX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4037,6 +4479,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX1" mode = "16:9">
+		<ID make="Panasonic" model="DMC-GX1">Panasonic DMC-GX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4050,6 +4493,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX1" mode = "1:1">
+		<ID make="Panasonic" model="DMC-GX1">Panasonic DMC-GX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4063,6 +4507,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX7">
+		<ID make="Panasonic" model="DMC-GX7">Panasonic DMC-GX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4076,6 +4521,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX7" mode = "4:3">
+		<ID make="Panasonic" model="DMC-GX7">Panasonic DMC-GX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4089,6 +4535,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX7" mode = "3:2">
+		<ID make="Panasonic" model="DMC-GX7">Panasonic DMC-GX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4102,6 +4549,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX7" mode = "16:9">
+		<ID make="Panasonic" model="DMC-GX7">Panasonic DMC-GX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4115,6 +4563,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-GX7" mode = "1:1">
+		<ID make="Panasonic" model="DMC-GX7">Panasonic DMC-GX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4128,6 +4577,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LF1" mode="4:3">
+		<ID make="Panasonic" model="DMC-LF1">Panasonic DMC-LF1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4142,6 +4592,7 @@
 	</Camera>
 	<!-- Default guess -->
 	<Camera make="Panasonic" model = "DMC-LF1">
+		<ID make="Panasonic" model="DMC-LF1">Panasonic DMC-LF1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4155,6 +4606,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX3">
+		<ID make="Panasonic" model="DMC-LX3">Panasonic DMC-LX3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4168,6 +4620,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX3" mode="16:9">
+		<ID make="Panasonic" model="DMC-LX3">Panasonic DMC-LX3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4181,6 +4634,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX3" mode="4:3">
+		<ID make="Panasonic" model="DMC-LX3">Panasonic DMC-LX3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4194,6 +4648,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX3" mode="3:2">
+		<ID make="Panasonic" model="DMC-LX3">Panasonic DMC-LX3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4207,6 +4662,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model="DIGILUX 2" decoder_version="2">
+		<ID make="Leica" model="Digilux 2">Leica Digilux 2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4217,6 +4673,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="LEICA" model="DIGILUX 2" mode="4:3" decoder_version="2">
+		<ID make="Leica" model="Digilux 2">Leica Digilux 2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4227,6 +4684,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="LEICA" model="D-LUX 3" decoder_version="2">
+		<ID make="Leica" model="D-LUX 3">Leica D-LUX 3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4237,6 +4695,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="LEICA" model="D-LUX 3" mode="16:9" decoder_version="2">
+		<ID make="Leica" model="D-LUX 3">Leica D-LUX 3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4247,6 +4706,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="LEICA" model="V-LUX 1" decoder_version="2">
+		<ID make="Leica" model="V-LUX 1">Leica V-LUX 1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4257,6 +4717,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="LEICA" model="V-LUX 1" mode="3:2" decoder_version="2">
+		<ID make="Leica" model="V-LUX 1">Leica V-LUX 1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4267,6 +4728,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-L10" decoder_version="2">
+		<ID make="Panasonic" model="DMC-L10">Panasonic DMC-L10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -4277,6 +4739,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-L10" mode="4:3" decoder_version="2">
+		<ID make="Panasonic" model="DMC-L10">Panasonic DMC-L10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -4287,6 +4750,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ30" decoder_version="2">
+		<ID make="Panasonic" model="DMC-FZ30">Panasonic DMC-FZ30</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4297,6 +4761,7 @@
 		<Sensor black="0" white="3971"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ30" mode="4:3" decoder_version="2">
+		<ID make="Panasonic" model="DMC-FZ30">Panasonic DMC-FZ30</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4307,6 +4772,7 @@
 		<Sensor black="0" white="3971"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ50" decoder_version="2">
+		<ID make="Panasonic" model="DMC-FZ50">Panasonic DMC-FZ50</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4317,6 +4783,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-FZ50" mode = "4:3" decoder_version="2">
+		<ID make="Panasonic" model="DMC-FZ50">Panasonic DMC-FZ50</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4327,6 +4794,7 @@
 		<Sensor black="0" white="65535"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ8" decoder_version="2">
+		<ID make="Panasonic" model="DMC-FZ8">Panasonic DMC-FZ8</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4337,6 +4805,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ8" mode="4:3"> decoder_version="2"
+		<ID make="Panasonic" model="DMC-FZ8">Panasonic DMC-FZ8</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4347,6 +4816,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ18" decoder_version="2">
+		<ID make="Panasonic" model="DMC-FZ18">Panasonic DMC-FZ18</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4357,6 +4827,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-FZ18" mode="4:3" decoder_version="2">
+		<ID make="Panasonic" model="DMC-FZ18">Panasonic DMC-FZ18</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4367,6 +4838,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-L1" decoder_version="2">
+		<ID make="Panasonic" model="DMC-L1">Panasonic DMC-L1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -4377,6 +4849,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-L1" mode="4:3" decoder_version="2">
+		<ID make="Panasonic" model="DMC-L1">Panasonic DMC-L1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -4387,6 +4860,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX2" decoder_version="2">
+		<ID make="Panasonic" model="DMC-LX2">Panasonic DMC-LX2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4397,6 +4871,7 @@
 		<Sensor black="0" white="3986"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX2" mode="16:9" decoder_version="2">
+		<ID make="Panasonic" model="DMC-LX2">Panasonic DMC-LX2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4408,6 +4883,7 @@
 	</Camera>
 	<!-- Leica D-Lux 4 is the same camera as LX-3 -->
 	<Camera make="LEICA" model = "D-LUX 4">
+		<ID make="Leica" model="D-LUX 4">Leica D-LUX 4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4421,6 +4897,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 4" mode="16:9">
+		<ID make="Leica" model="D-LUX 4">Leica D-LUX 4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4434,6 +4911,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 4" mode="4:3">
+		<ID make="Leica" model="D-LUX 4">Leica D-LUX 4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4447,6 +4925,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 4" mode="3:2">
+		<ID make="Leica" model="D-LUX 4">Leica D-LUX 4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4461,6 +4940,7 @@
 	</Camera>
 
 	<Camera make="Panasonic" model = "DMC-LX5">
+		<ID make="Panasonic" model="DMC-LX5">Panasonic DMC-LX5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4474,6 +4954,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX5" mode="4:3">
+		<ID make="Panasonic" model="DMC-LX5">Panasonic DMC-LX5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4487,6 +4968,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX5" mode="3:2">
+		<ID make="Panasonic" model="DMC-LX5">Panasonic DMC-LX5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4500,6 +4982,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX5" mode="16:9">
+		<ID make="Panasonic" model="DMC-LX5">Panasonic DMC-LX5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4513,6 +4996,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX5" mode="1:1">
+		<ID make="Panasonic" model="DMC-LX5">Panasonic DMC-LX5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4527,6 +5011,7 @@
 	</Camera>
 	<!-- Leica D-Lux 5 is the same camera as LX-5 -->
 	<Camera make="LEICA" model = "D-LUX 5">
+		<ID make="Leica" model="D-LUX 5">Leica D-LUX 5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4540,6 +5025,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 5" mode="4:3">
+		<ID make="Leica" model="D-LUX 5">Leica D-LUX 5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4553,6 +5039,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 5" mode="3:2">
+		<ID make="Leica" model="D-LUX 5">Leica D-LUX 5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4566,6 +5053,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 5" mode="16:9">
+		<ID make="Leica" model="D-LUX 5">Leica D-LUX 5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4579,6 +5067,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 5" mode="1:1">
+		<ID make="Leica" model="D-LUX 5">Leica D-LUX 5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4592,6 +5081,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX7">
+		<ID make="Panasonic" model="DMC-LX7">Panasonic DMC-LX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4605,6 +5095,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX7" mode="4:3">
+		<ID make="Panasonic" model="DMC-LX7">Panasonic DMC-LX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4618,6 +5109,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX7" mode="3:2">
+		<ID make="Panasonic" model="DMC-LX7">Panasonic DMC-LX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4631,6 +5123,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX7" mode="16:9">
+		<ID make="Panasonic" model="DMC-LX7">Panasonic DMC-LX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4644,6 +5137,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model = "DMC-LX7" mode="1:1">
+		<ID make="Panasonic" model="DMC-LX7">Panasonic DMC-LX7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4658,6 +5152,7 @@
 	</Camera>
 	<!-- LEICA D-LUX 6 is the same camera as Panasonic DMC-LX7 -->
 	<Camera make="LEICA" model = "D-LUX 6">
+		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4671,6 +5166,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 6" mode="4:3">
+		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4684,6 +5180,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 6" mode="3:2">
+		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4697,6 +5194,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 6" mode="16:9">
+		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4710,6 +5208,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="LEICA" model = "D-LUX 6" mode="1:1">
+		<ID make="Leica" model="D-LUX 6">Leica D-LUX 6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -4723,6 +5222,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX1" mode="16:9">
+		<ID make="Panasonic" model="DMC-LX1">Panasonic DMC-LX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4733,6 +5233,7 @@
 		<Sensor black="0" white="3971"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX1">
+		<ID make="Panasonic" model="DMC-LX1">Panasonic DMC-LX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4743,6 +5244,7 @@
 		<Sensor black="0" white="3971"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX100">
+		<ID make="Panasonic" model="DMC-LX100">Panasonic DMC-LX100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4753,6 +5255,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX100" mode="4:3">
+		<ID make="Panasonic" model="DMC-LX100">Panasonic DMC-LX100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4763,6 +5266,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX100" mode="16:9">
+		<ID make="Panasonic" model="DMC-LX100">Panasonic DMC-LX100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4773,6 +5277,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX100" mode="3:2">
+		<ID make="Panasonic" model="DMC-LX100">Panasonic DMC-LX100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4783,6 +5288,7 @@
 		<Sensor black="143" white="4095"/>
 	</Camera>
 	<Camera make="Panasonic" model="DMC-LX100" mode="1:1">
+		<ID make="Panasonic" model="DMC-LX100">Panasonic DMC-LX100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4843,6 +5349,7 @@
 		<Sensor black="145" white="3956"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX K100D">
+		<ID make="Pentax" model="K100D">Pentax K100D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4853,6 +5360,7 @@
 		<Sensor black="127" white="3950"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX K110D">
+		<ID make="Pentax" model="K110D">Pentax K110D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4863,6 +5371,7 @@
 		<Sensor black="127" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX K100D Super">
+		<ID make="Pentax" model="K100D Super">Pentax K100D Super</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4873,6 +5382,7 @@
 		<Sensor black="127" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K100D">
+		<ID make="Pentax" model="K100D">Pentax K100D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4883,6 +5393,7 @@
 		<Sensor black="127" white="3950"/>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K110D">
+		<ID make="Pentax" model="K110D">Pentax K110D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4893,6 +5404,7 @@
 		<Sensor black="127" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX *ist D">
+		<ID make="Pentax" model="*ist D">Pentax *ist D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4903,6 +5415,7 @@
 		<Sensor black="128" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX *ist DL">
+		<ID make="Pentax" model="*ist DL">Pentax *ist DL</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4913,6 +5426,7 @@
 		<Sensor black="128" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX *ist DL2">
+		<ID make="Pentax" model="*ist DL2">Pentax *ist DL2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4923,6 +5437,7 @@
 		<Sensor black="127" white="3950"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX *ist DS">
+		<ID make="Pentax" model="*ist DS">Pentax *ist DS</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4933,6 +5448,7 @@
 		<Sensor black="128" white="3950"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX K10D">
+		<ID make="Pentax" model="K10D">Pentax K10D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4943,6 +5459,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX K20D">
+		<ID make="Pentax" model="K20D">Pentax K20D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4953,6 +5470,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K20D">
+		<ID make="Pentax" model="K20D">Pentax K20D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4963,6 +5481,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX Corporation" model="PENTAX K200D">
+		<ID make="Pentax" model="K200D">Pentax K200D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4973,6 +5492,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-3">
+		<ID make="Pentax" model="K-3">Pentax K-3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4983,6 +5503,7 @@
 		<Sensor black="1" white="15868"/>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K-5" decoder_version="2">
+		<ID make="Pentax" model="K-5">PENTAX K-5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -4996,6 +5517,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K-5 II" decoder_version="2">
+		<ID make="Pentax" model="K-5 II">PENTAX K-5 II</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5009,6 +5531,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K-5 II s" decoder_version="2">
+		<ID make="Pentax" model="K-5 II s">PENTAX K-5 II s</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5022,6 +5545,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K-7">
+		<ID make="Pentax" model="K-7">PENTAX K-7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5032,6 +5556,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K-m">
+		<ID make="Pentax" model="K-m">Pentax K-m</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5042,6 +5567,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K-x">
+		<ID make="Pentax" model="K-x">PENTAX K-x</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5055,6 +5581,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K-r" decoder_version="3">
+		<ID make="Pentax" model="K-r">PENTAX K-r</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5065,6 +5592,7 @@
 		<Sensor black="64" white="4000"/>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K200D">
+		<ID make="Pentax" model="K200D">Pentax K200D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5075,6 +5603,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="PENTAX" model="PENTAX K2000">
+		<ID make="Pentax" model="K2000">Pentax K2000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5085,6 +5614,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="EX2F">
+		<ID make="Samsung" model="EX2F">Samsung EX2F</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5095,6 +5625,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="EX1">
+		<ID make="Samsung" model="EX1">Samsung EX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5105,6 +5636,7 @@
 		<Sensor black="0" white="16383"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX1">
+		<ID make="Samsung" model="NX1">Samsung NX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5117,6 +5649,7 @@
 		<Sensor black="128" white="16100"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX5">
+		<ID make="Samsung" model="NX5">Samsung NX5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5130,6 +5663,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX10">
+		<ID make="Samsung" model="NX10">Samsung NX10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5144,6 +5678,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX11">
+		<ID make="Samsung" model="NX11">Samsung NX11</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5157,6 +5692,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX100">
+		<ID make="Samsung" model="NX100">Samsung NX100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5171,6 +5707,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX1000" decoder_version="2">
+		<ID make="Samsung" model="NX1000">Samsung NX1000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5184,6 +5721,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX1100" decoder_version="2">
+		<ID make="Samsung" model="NX1100">Samsung NX1100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5197,6 +5735,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX20" decoder_version="2">
+		<ID make="Samsung" model="NX20">Samsung NX20</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5210,6 +5749,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX200" decoder_version="2">
+		<ID make="Samsung" model="NX200">Samsung NX200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5223,6 +5763,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX210" decoder_version="2">
+		<ID make="Samsung" model="NX210">Samsung NX210</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5236,6 +5777,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX2000" decoder_version="3">
+		<ID make="Samsung" model="NX2000">Samsung NX2000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5246,6 +5788,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX30" decoder_version="3">
+		<ID make="Samsung" model="NX30">Samsung NX30</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5256,6 +5799,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX300" decoder_version="3">
+		<ID make="Samsung" model="NX300">Samsung NX300</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5269,6 +5813,7 @@
 		</Aliases>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX3000">
+		<ID make="Samsung" model="NX3000">Samsung NX3000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5279,6 +5824,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="NX500">
+		<ID make="Samsung" model="NX500">Samsung NX500</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5291,6 +5837,7 @@
 		<Sensor black="128" white="16100"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="EK-GN120" decoder_version="3">
+		<ID make="Samsung" model="EK-GN120">Samsung EK-GN120</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -5301,6 +5848,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SAMSUNG" model="WB2000">
+		<ID make="Samsung" model="WB2000">Samsung WB2000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5311,6 +5859,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSC-RX10">
+		<ID make="Sony" model="DSC-RX10">Sony DSC-RX10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5326,6 +5875,7 @@
 		<Sensor black="1245" white="16384"/>
 	</Camera>
 	<Camera make="SONY" model="DSC-RX100">
+		<ID make="Sony" model="DSC-RX100">Sony DSC-RX100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5336,6 +5886,7 @@
 		<Sensor black="800" white="16620"/>
 	</Camera>
 	<Camera make="SONY" model="DSC-RX100M2">
+		<ID make="Sony" model="DSC-RX100M2">Sony DSC-RX100M2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5346,6 +5897,7 @@
 		<Sensor black="800" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="DSC-RX100M3">
+		<ID make="Sony" model="DSC-RX100M3">Sony DSC-RX100M3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5356,6 +5908,7 @@
 		<Sensor black="800" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="DSC-RX1R">
+		<ID make="Sony" model="DSC-RX1R">Sony DSC-RX1R</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5370,6 +5923,7 @@
 		</BlackAreas>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A100" decoder_version="1">
+		<ID make="Sony" model="DSLR-A100">Sony DSLR-A100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -5380,6 +5934,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A200">
+		<ID make="Sony" model="DSLR-A200">Sony DSLR-A200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5390,6 +5945,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A230">
+		<ID make="Sony" model="DSLR-A230">Sony DSLR-A230</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5400,6 +5956,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A290">
+		<ID make="Sony" model="DSLR-A290">Sony DSLR-A290</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5410,6 +5967,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A300">
+		<ID make="Sony" model="DSLR-A300">Sony DSLR-A300</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5420,6 +5978,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A330">
+		<ID make="Sony" model="DSLR-A330">Sony DSLR-A330</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5430,6 +5989,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A350">
+		<ID make="Sony" model="DSLR-A350">Sony DSLR-A350</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5440,6 +6000,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A390">
+		<ID make="Sony" model="DSLR-A390">Sony DSLR-A390</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5450,6 +6011,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A450">
+		<ID make="Sony" model="DSLR-A450">Sony DSLR-A450</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5460,6 +6022,7 @@
 		<Sensor black="500" white="16000"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A500">
+		<ID make="Sony" model="DSLR-A500">Sony DSLR-A500</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5470,6 +6033,7 @@
 		<Sensor black="500" white="16600"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A550">
+		<ID make="Sony" model="DSLR-A550">Sony DSLR-A550</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5480,6 +6044,7 @@
 		<Sensor black="512" white="16372"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A560">
+		<ID make="Sony" model="DSLR-A560">Sony DSLR-A560</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5490,6 +6055,7 @@
 		<Sensor black="476" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A580">
+		<ID make="Sony" model="DSLR-A580">Sony DSLR-A580</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5500,6 +6066,7 @@
 		<Sensor black="520" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A700">
+		<ID make="Sony" model="DSLR-A700">Sony DSLR-A700</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5510,6 +6077,7 @@
 		<Sensor black="520" white="16383"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A850">
+		<ID make="Sony" model="DSLR-A850">Sony DSLR-A850</ID>
 		<CFA width="2" height="2">
 			<Color x="1" y="1">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5520,6 +6088,7 @@
 		<Sensor black="500" white="15000"/>
 	</Camera>
 	<Camera make="SONY" model="DSLR-A900">
+		<ID make="Sony" model="DSLR-A900">Sony DSLR-A900</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5530,6 +6099,7 @@
 		<Sensor black="520" white="16383"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-3">
+		<ID make="Sony" model="NEX-3">Sony NEX-3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5540,6 +6110,7 @@
 		<Sensor black="520" white="16360"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-3N">
+		<ID make="Sony" model="NEX-3N">Sony NEX-3N</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5550,6 +6121,7 @@
 		<Sensor black="520" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-5">
+		<ID make="Sony" model="NEX-5">Sony NEX-5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5560,6 +6132,7 @@
 		<Sensor black="520" white="16383"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-5N">
+		<ID make="Sony" model="NEX-5N">Sony NEX-5N</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5570,6 +6143,7 @@
 		<Sensor black="520" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-5R">
+		<ID make="Sony" model="NEX-5R">Sony NEX-5R</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5580,6 +6154,7 @@
 		<Sensor black="520" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-5T">
+		<ID make="Sony" model="NEX-5T">Sony NEX-5T</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5590,6 +6165,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-6">
+		<ID make="Sony" model="NEX-6">Sony NEX-6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5601,6 +6177,7 @@
 	</Camera>
 	<!-- Measured on images from https://github.com/klauspost/rawspeed/issues/78 -->
 	<Camera make="SONY" model="NEX-7">
+		<ID make="Sony" model="NEX-7">Sony NEX-7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5611,6 +6188,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-C3">
+		<ID make="Sony" model="NEX-C3">Sony NEX-C3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5621,6 +6199,7 @@
 		<Sensor black="520" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="NEX-F3">
+		<ID make="Sony" model="NEX-F3">Sony NEX-F3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5631,6 +6210,7 @@
 		<Sensor black="520" white="16360"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-3000">
+		<ID make="Sony" model="ILCE-3000">Sony ILCE-3000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5641,6 +6221,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-3500">
+		<ID make="Sony" model="ILCE-3500">Sony ILCE-3500</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5651,6 +6232,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-5000">
+		<ID make="Sony" model="ILCE-5000">Sony ILCE-5000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5661,6 +6243,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-5100">
+		<ID make="Sony" model="ILCE-5100">Sony ILCE-5100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5671,6 +6254,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-6000">
+		<ID make="Sony" model="ILCE-6000">Sony ILCE-6000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5681,6 +6265,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-7">
+		<ID make="Sony" model="ILCE-7">Sony ILCE-7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5691,6 +6276,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-7M2">
+		<ID make="Sony" model="ILCE-7M2">Sony ILCE-7M2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5701,6 +6287,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-7R">
+		<ID make="Sony" model="ILCE-7R">Sony ILCE-7R</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5711,6 +6298,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="ILCE-7S">
+		<ID make="Sony" model="ILCE-7S">Sony ILCE-7S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5721,6 +6309,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="DSC-RX1">
+		<ID make="Sony" model="DSC-RX1">Sony DSC-RX1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5731,6 +6320,7 @@
 		<Sensor black="520" white="16628"/>
 	</Camera>
 	<Camera make="SONY" model="SLT-A33">
+		<ID make="Sony" model="SLT-A33">Sony SLT-A33</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5741,6 +6331,7 @@
 		<Sensor black="520" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="SLT-A35">
+		<ID make="Sony" model="SLT-A35">Sony SLT-A35</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5751,6 +6342,7 @@
 		<Sensor black="545" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="SLT-A37">
+		<ID make="Sony" model="SLT-A37">Sony SLT-A37</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5761,6 +6353,7 @@
 		<Sensor black="520" white="16500"/>
 	</Camera>
 	<Camera make="SONY" model="SLT-A55">
+		<ID make="Sony" model="SLT-A55">Sony SLT-A55</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5770,10 +6363,11 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="520" white="16596"/>
 		<Aliases>
-			<Alias>SLT-A55V</Alias>
+			<Alias id="SLT-A55">SLT-A55V</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="SONY" model="SLT-A57">
+		<ID make="Sony" model="SLT-A57">Sony SLT-A57</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5784,6 +6378,7 @@
 		<Sensor black="512" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="SLT-A58">
+		<ID make="Sony" model="SLT-A58">Sony SLT-A58</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5794,6 +6389,7 @@
 		<Sensor black="520" white="16596"/>
 	</Camera>
 	<Camera make="SONY" model="SLT-A65">
+		<ID make="Sony" model="SLT-A65">Sony SLT-A65</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5803,10 +6399,11 @@
 		<Crop x="0" y="0" width="-30" height="0"/>
 		<Sensor black="520" white="16596"/>
 		<Aliases>
-			<Alias>SLT-A65V</Alias>
+			<Alias id="SLT-A65">SLT-A65V</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="SONY" model="SLT-A77">
+		<ID make="Sony" model="SLT-A77">Sony SLT-A77</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5816,10 +6413,11 @@
 		<Crop x="0" y="0" width="-28" height="0"/>
 		<Sensor black="520" white="16596"/>
 		<Aliases>
-			<Alias>SLT-A77V</Alias>
+			<Alias id="SLT-A77">SLT-A77V</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="SONY" model="ILCA-77M2">
+		<ID make="Sony" model="ILCA-77M2">Sony ILCA-77M2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5830,6 +6428,7 @@
 		<Sensor black="512" white="16300"/>
 	</Camera>
 	<Camera make="SONY" model="SLT-A99">
+		<ID make="Sony" model="SLT-A99">Sony SLT-A99</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5839,10 +6438,11 @@
 		<Crop x="0" y="0" width="-28" height="0"/>
 		<Sensor black="520" white="16596"/>
 		<Aliases>
-			<Alias>SLT-A99V</Alias>
+			<Alias id="SLT-A99">SLT-A99V</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Sinar Photography AG" model="Sinar Hy6/ Sinarback eXact" mode="dng">
+		<ID make="Sinar" model="Hy6">Sinar Hy6</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5856,6 +6456,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S6000fd">
+		<ID make="Fujifilm" model="FinePix S6000fd">Fujifilm FinePix S6000fd</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5866,6 +6467,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S200EXR">
+		<ID make="Fujifilm" model="FinePix S200EXR">Fujifilm FinePix S200EXR</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5875,7 +6477,19 @@
 		<Crop x="28" y="0" width="-28" height="0"/>
 		<Sensor black="519" white="16250"/>
 	</Camera>
+	<Camera make="FUJIFILM" model="FinePix F600EXR">
+		<ID make="Fujifilm" model="FinePix F600EXR">Fujifilm FinePix F600EXR</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="34" y="0" width="-32" height="0"/>
+		<Sensor black="256" white="3900"/>
+	</Camera>
 	<Camera make="FUJIFILM" model="FinePix F700">
+		<ID make="Fujifilm" model="FinePix F700">Fujifilm FinePix F700</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5888,6 +6502,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix F900EXR">
+		<ID make="Fujifilm" model="FinePix F900EXR">Fujifilm FinePix F900EXR</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -5898,6 +6513,7 @@
 		<Sensor black="256" white="3900"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix E550">
+		<ID make="Fujifilm" model="FinePix E550">Fujifilm FinePix E550</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5909,6 +6525,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="IS-1">
+		<ID make="Fujifilm" model="IS-1">Fujifilm IS-1</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5920,6 +6537,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S3Pro">
+		<ID make="Fujifilm" model="FinePix S3Pro">Fujifilm FinePix S3Pro</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5931,6 +6549,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S5Pro">
+		<ID make="Fujifilm" model="FinePix S5Pro">Fujifilm FinePix S5Pro</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5942,6 +6561,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S5600">
+		<ID make="Fujifilm" model="FinePix S5600">Fujifilm FinePix S5600</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5953,6 +6573,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix E900">
+		<ID make="Fujifilm" model="FinePix E900">Fujifilm FinePix E900</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5964,6 +6585,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePixS2Pro">
+		<ID make="Fujifilm" model="FinePix S2Pro">Fujifilm FinePix S2Pro</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5975,6 +6597,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S5000">
+		<ID make="Fujifilm" model="FinePix S5000">Fujifilm FinePix S5000</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5986,6 +6609,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S5200">
+		<ID make="Fujifilm" model="FinePix S5200">Fujifilm FinePix S5200</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -5997,6 +6621,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S5500">
+		<ID make="Fujifilm" model="FinePix S5500">Fujifilm FinePix S5500</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">RG</ColorRow>
 			<ColorRow y="1">GB</ColorRow>
@@ -6005,6 +6630,7 @@
 		<Sensor black="0" white="15872"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S6500fd">
+		<ID make="Fujifilm" model="FinePix S6500fd">Fujifilm FinePix S6500fd</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -6016,6 +6642,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S9500">
+		<ID make="Fujifilm" model="FinePix S9500">Fujifilm FinePix S9500</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -6030,6 +6657,7 @@
 		</Aliases>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S9600">
+		<ID make="Fujifilm" model="FinePix S9600">Fujifilm FinePix S9600</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -6041,6 +6669,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S9600fd">
+		<ID make="Fujifilm" model="FinePix S9600fd">Fujifilm FinePix S9600fd</ID>
 		<CFA2 width="2" height="2">
 			<ColorRow y="0">GB</ColorRow>
 			<ColorRow y="1">RG</ColorRow>
@@ -6052,6 +6681,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix HS10 HS11">
+		<ID make="Fujifilm" model="FinePix HS10 HS11">Fujifilm FinePix HS10 HS11</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6065,6 +6695,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix HS20EXR">
+		<ID make="Fujifilm" model="FinePix HS20EXR">Fujifilm FinePix HS20EXR</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6075,6 +6706,7 @@
 		<Sensor black="256" white="3900"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix HS30EXR">
+		<ID make="Fujifilm" model="FinePix HS30EXR">Fujifilm FinePix HS30EXR</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6085,6 +6717,7 @@
 		<Sensor black="258" white="3900"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix HS50EXR">
+		<ID make="Fujifilm" model="FinePix HS50EXR">Fujifilm FinePix HS50EXR</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6095,6 +6728,7 @@
 		<Sensor black="256" white="3900"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="FinePix X100">
+		<ID make="Fujifilm" model="FinePix X100">Fujifilm FinePix X100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6105,6 +6739,7 @@
 		<Sensor black="254" white="4000"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X10">
+		<ID make="Fujifilm" model="FinePix X10">Fujifilm FinePix X10</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6115,6 +6750,7 @@
 		<Sensor black="256" white="4000"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-S1">
+		<ID make="Fujifilm" model="X-S1">Fujifilm X-S1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6125,6 +6761,7 @@
 		<Sensor black="260" white="4000"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-Pro1">
+		<ID make="Fujifilm" model="X-Pro1">Fujifilm X-Pro1</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">GGRGGB</ColorRow>
 			<ColorRow y="1">GGBGGR</ColorRow>
@@ -6137,6 +6774,7 @@
 		<Sensor black="256" white="4094"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="XF1">
+		<ID make="Fujifilm" model="XF1">Fujifilm XF1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6147,6 +6785,7 @@
 		<Sensor black="257" white="4000"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-E1">
+		<ID make="Fujifilm" model="X-E1">Fujifilm X-E1</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">GGRGGB</ColorRow>
 			<ColorRow y="1">GGBGGR</ColorRow>
@@ -6159,6 +6798,7 @@
 		<Sensor black="255" white="4094"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X20">
+		<ID make="Fujifilm" model="X20">Fujifilm X20</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">GBGGRG</ColorRow>
 			<ColorRow y="1">RGRBGB</ColorRow>
@@ -6171,6 +6811,7 @@
 		<Sensor black="257" white="4094"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X30">
+		<ID make="Fujifilm" model="X30">Fujifilm X30</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">GBGGRG</ColorRow>
 			<ColorRow y="1">RGRBGB</ColorRow>
@@ -6183,6 +6824,7 @@
 		<Sensor black="257" white="4094"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X100S">
+		<ID make="Fujifilm" model="X100S">Fujifilm X100S</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">RBGBRG</ColorRow>
 			<ColorRow y="1">GGRGGB</ColorRow>
@@ -6195,6 +6837,7 @@
 		<Sensor black="1024" white="16383"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X100T">
+		<ID make="Fujifilm" model="X100T">Fujifilm X100T</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">RBGBRG</ColorRow>
 			<ColorRow y="1">GGRGGB</ColorRow>
@@ -6207,6 +6850,7 @@
 		<Sensor black="1024" white="16383"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-M1">
+		<ID make="Fujifilm" model="X-M1">Fujifilm X-M1</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">GGRGGB</ColorRow>
 			<ColorRow y="1">GGBGGR</ColorRow>
@@ -6219,6 +6863,7 @@
 		<Sensor black="256" white="4094"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-A1">
+		<ID make="Fujifilm" model="X-A1">Fujifilm X-A1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6229,6 +6874,7 @@
 		<Sensor black="256" white="4094"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="XQ1">
+		<ID make="Fujifilm" model="XQ1">Fujifilm XQ1</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">GBGGRG</ColorRow>
 			<ColorRow y="1">RGRBGB</ColorRow>
@@ -6241,6 +6887,7 @@
 		<Sensor black="257" white="4094"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-E2">
+		<ID make="Fujifilm" model="X-E2">Fujifilm X-E2</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">RBGBRG</ColorRow>
 			<ColorRow y="1">GGRGGB</ColorRow>
@@ -6253,6 +6900,7 @@
 		<Sensor black="1024" white="16383"/>
 	</Camera>
 	<Camera make="FUJIFILM" model="X-T1">
+		<ID make="Fujifilm" model="X-T1">Fujifilm X-T1</ID>
 		<CFA2 width="6" height="6">
 			<ColorRow y="0">RBGBRG</ColorRow>
 			<ColorRow y="1">GGRGGB</ColorRow>
@@ -6264,7 +6912,8 @@
 		<Crop x="4" y="0" width="-52" height="0"/>
 		<Sensor black="1024" white="16383"/>
 	</Camera>
-	<Camera make="MINOLTA" model="DYNAX 5D">
+	<Camera make="KONICA MINOLTA" model="DYNAX 5D">
+		<ID make="Minolta" model="Dynax 5D">Konica Minolta Maxxum 5D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6273,8 +6922,13 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
+		<Aliases>
+			<Alias id="Maxxum 5D">MAXXUM 5D</Alias>
+			<Alias id="Alpha 5D">ALPHA 5D</Alias>
+		</Aliases>
 	</Camera>
-  <Camera make="MINOLTA" model="DYNAX 7D">
+	<Camera make="KONICA MINOLTA" model="DYNAX 7D">
+		<ID make="Minolta" model="Dynax 7D">Konica Minolta Maxxum 7D</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6283,8 +6937,13 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
+		<Aliases>
+			<Alias id="Maxxum 7D">MAXXUM 7D</Alias>
+			<Alias id="Alpha 7D">ALPHA 7D</Alias>
+		</Aliases>
 	</Camera>
-	<Camera make="MINOLTA" model="DIMAGE A1">
+	<Camera make="Minolta Co., Ltd." model="DiMAGE A1">
+		<ID make="Minolta" model="DiMAGE A1">Minolta DiMAGE A1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6294,7 +6953,8 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
 	</Camera>
-	<Camera make="MINOLTA" model="DIMAGE A2">
+	<Camera make="Konica Minolta Camera, Inc." model="DiMAGE A2">
+		<ID make="Minolta" model="DiMAGE A2">Konica Minolta DiMAGE A2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6304,7 +6964,8 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
 	</Camera>
-	<Camera make="MINOLTA" model="DIMAGE A200">
+	<Camera make="KONICA MINOLTA" model="DiMAGE A200">
+		<ID make="Minolta" model="DiMAGE A200">Konica Minolta DiMAGE A200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">BLUE</Color>
@@ -6313,8 +6974,12 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
+		<Hints>
+			<Hint name="swapped_wb" value=""/>
+		</Hints>
 	</Camera>
-	<Camera make="MINOLTA" model="DIMAGE 5">
+	<Camera make="Minolta Co., Ltd." model="DiMAGE 5">
+		<ID make="Minolta" model="DiMAGE 5">Minolta DiMAGE 5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6324,7 +6989,8 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
 	</Camera>
-	<Camera make="MINOLTA" model="DIMAGE 7">
+	<Camera make="Minolta Co., Ltd." model="DiMAGE 7">
+		<ID make="Minolta" model="DiMAGE 7">Minolta DiMAGE 7</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6334,7 +7000,8 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
 	</Camera>
-	<Camera make="MINOLTA" model="DIMAGE 7I">
+	<Camera make="Minolta Co., Ltd." model="DiMAGE 7i">
+		<ID make="Minolta" model="DiMAGE 7i">Minolta DiMAGE 7i</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6344,7 +7011,8 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
 	</Camera>
-	<Camera make="MINOLTA" model="DIMAGE 7HI">
+	<Camera make="Minolta Co., Ltd." model="DiMAGE 7Hi">
+		<ID make="Minolta" model="DiMAGE 7Hi">Minolta DiMAGE 7Hi</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6355,6 +7023,7 @@
 		<Sensor black="0" white="3965"/>
 	</Camera>
 	<Camera make="SONY" model="DSC-R1">
+		<ID make="Sony" model="DSC-R1">Sony DSC-R1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
 			<Color x="1" y="0">RED</Color>
@@ -6365,6 +7034,7 @@
 		<Sensor black="511" white="16383"/>
 	</Camera>
 	<Camera make="Mamiya-OP Co.,Ltd." model="MAMIYA ZD">
+		<ID make="Mamiya" model="ZD">Mamiya ZD</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6378,6 +7048,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="Creo/Leaf" model="Leaf Aptus 22(LF3779     )/Hasselblad H1">
+		<ID make="Leaf" model="Aptus 22">Leaf Aptus 22</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6398,6 +7069,7 @@
 		<Sensor black="0" white="3700"/>
 	</Camera>
 	<Camera make="EASTMAN KODAK COMPANY" model="KODAK P880 ZOOM DIGITAL CAMERA">
+		<ID make="Kodak" model="P880">Kodak P880</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6408,6 +7080,7 @@
 		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="EASTMAN KODAK COMPANY" model="KODAK EASYSHARE Z1015 IS DIGITAL CAMERA">
+		<ID make="Kodak" model="Z1015 IS">Kodak Z1015 IS</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6421,6 +7094,7 @@
 		</Hints>
 	</Camera>
 	<Camera make="SEIKO EPSON CORP." model="R-D1">
+		<ID make="Epson" model="R-D1">Epson R-D1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6431,6 +7105,7 @@
 		<Sensor black="63" white="4095"/>
 	</Camera>
 	<Camera make="Hasselblad" model="Hasselblad 500 mech.">
+		<ID make="Hasselblad" model="CFV">Hasselblad 16-Uncoated</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6441,6 +7116,7 @@
 		<Sensor black="" white="32767"/>
 	</Camera>
 	<Camera make="Hasselblad" model="Hasselblad H3D">
+		<ID make="Hasselblad" model="H3D">Hasselblad 39-Coated</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
@@ -6449,6 +7125,56 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="31456"/>
+	</Camera>
+	<Camera make="Hasselblad" model="Flash Sync">
+		<ID make="Hasselblad" model="CF132">Hasselblad 22-Uncoated</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="62914"/>
+	</Camera>
+	<Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX 645Z" mode="dng">
+		<ID make="Pentax" model="645Z">PENTAX 645Z</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX 645D" mode="dng">
+		<ID make="Pentax" model="645D">PENTAX 645D</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX K-01" mode="dng">
+		<ID make="Pentax" model="K-01">PENTAX K-01</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX K-30" mode="dng">
+		<ID make="Pentax" model="K-30">PENTAX K-30</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX K-50" mode="dng">
+		<ID make="Pentax" model="K-50">PENTAX K-50</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX K-500" mode="dng">
+		<ID make="Pentax" model="K-500">PENTAX K-500</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX Q" mode="dng">
+		<ID make="Pentax" model="Q">PENTAX Q</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX Q7" mode="dng">
+		<ID make="Pentax" model="Q7">PENTAX Q7</ID>
+	</Camera>
+	<Camera make="PENTAX" model="PENTAX Q10" mode="dng">
+		<ID make="Pentax" model="Q10">PENTAX Q10</ID>
+	</Camera>
+	<Camera make="PENTAX RICOH IMAGING" model="PENTAX MX-1" mode="dng">
+		<ID make="Pentax" model="MX-1">PENTAX MX-1</ID>
+	</Camera>
+	<Camera make="Leica Camera AG" model="M8 Digital Camera" mode="dng">
+		<ID make="Leica" model="M8">M8 Digital Camera</ID>
+	</Camera>
+	<Camera make="Canon" model="Canon PowerShot SX100 IS" mode="dng">
+		<ID make="Canon" model="PowerShot SX100 IS">Canon PowerShot SX100 IS</ID>
+	</Camera>
+	<Camera make="Canon" model="Canon PowerShot A3200 IS" mode="dng">
+		<ID make="Canon" model="PowerShot A3200 IS">Canon PowerShot A3200 IS</ID>
 	</Camera>
 	<!-- CHDK Cameras -->
 	<Camera make="AVT" model="F-080C" mode="chdk">


### PR DESCRIPTION
As discussed in issue #95 this adds a new tag and some code so rawspeed produces clean names for cameras. I've added IDs to all cameras and aliases and this has been working well for darktable both as a way to reference cameras in external databases (matrices, wb presets, etc) and as a way to show clean camera names in the UI.
