### PR TITLE
Fix a buffer overflow in CRW

### DIFF
--- a/RawSpeed/CrwDecoder.cpp
+++ b/RawSpeed/CrwDecoder.cpp
@@ -218,7 +218,7 @@ void CrwDecoder::makeDecoder (int n, const uchar8 *source)
     mHuff[n] = NULL;
   }
 
-  ushort16* huff = (ushort16 *) _aligned_malloc((1 + (1 << max)* sizeof(ushort16)), 16);
+  ushort16* huff = (ushort16 *) _aligned_malloc((1 + (1 << max)) * sizeof(ushort16), 16);
   
   if (!huff)
     ThrowRDE("CRW: Couldn't allocate table");


### PR DESCRIPTION
Seems like there was a typo in the conversion between calloc and malloc so the size was being miscalculated.
