### PR TITLE
Support a few more old Kodak DSLRs

### DIFF
--- a/RawSpeed/DcrDecoder.cpp
+++ b/RawSpeed/DcrDecoder.cpp
@@ -39,12 +39,15 @@ RawImage DcrDecoder::decodeRawInternal() {
 
   if (data.size() < 1)
     ThrowRDE("DCR Decoder: No image data found");
-    
+
   TiffIFD* raw = data[0];
   uint32 width = raw->getEntry(IMAGEWIDTH)->getInt();
   uint32 height = raw->getEntry(IMAGELENGTH)->getInt();
   uint32 off = raw->getEntry(STRIPOFFSETS)->getInt();
   uint32 c2 = raw->getEntry(STRIPBYTECOUNTS)->getInt();
+
+  if (off > mFile->getSize())
+    ThrowRDE("DCR Decoder: Offset is out of bounds");
 
   if (c2 > mFile->getSize() - off) {
     mRaw->setError("Warning: byte count larger than file size, file probably truncated.");

--- a/RawSpeed/DcrDecoder.cpp
+++ b/RawSpeed/DcrDecoder.cpp
@@ -73,6 +73,9 @@ RawImage DcrDecoder::decodeRawInternal() {
       ThrowRDE("DCR Decoder: Couldn't find the linearization table");
     }
 
+    if (!uncorrectedRawValues)
+      mRaw->setTable(linearization->getShortArray(), 1024, true);
+
     // FIXME: dcraw does all sorts of crazy things besides this to fetch
     //        WB from what appear to be presets and calculate it in weird ways
     //        The only file I have only uses this method, if anybody careas look
@@ -85,20 +88,19 @@ RawImage DcrDecoder::decodeRawInternal() {
       mRaw->metadata.wbCoeffs[2] = (float) 2048.0f / data[22];
     }
 
-    // Get create passthrough curve if user has requested that.
-    if (uncorrectedRawValues) {
-      for (int i = 0; i < 1024; i++)
-        linear[i] = i;
-    }
-
     try {
-      if (uncorrectedRawValues)
-        decodeKodak65000(input, width, height, linear);
-      else
-        decodeKodak65000(input, width, height, linearization->getShortArray());
+      decodeKodak65000(input, width, height);
     } catch (IOException) {
       mRaw->setError("IO error occurred while reading image. Returning partial result.");
     }
+
+    // Set the table, if it should be needed later.
+    if (uncorrectedRawValues) {
+      mRaw->setTable(linearization->getShortArray(), 1024, false);
+    } else {
+      mRaw->setTable(NULL);
+    }
+
     delete kodakifd;
   } else
     ThrowRDE("DCR Decoder: Unsupported compression %d", compression);
@@ -106,12 +108,13 @@ RawImage DcrDecoder::decodeRawInternal() {
   return mRaw;
 }
 
-void DcrDecoder::decodeKodak65000(ByteStream &input, uint32 w, uint32 h, const ushort16 *curve) {
+void DcrDecoder::decodeKodak65000(ByteStream &input, uint32 w, uint32 h) {
   ushort16 buf[256];
   uint32 pred[2];
   uchar8* data = mRaw->getData();
   uint32 pitch = mRaw->pitch;
 
+  uint32 random = 0;
   for (uint32 y = 0; y < h; y++) {
     ushort16* dest = (ushort16*) & data[y*pitch];
     for (uint32 x = 0 ; x < w; x += 256) {
@@ -122,7 +125,10 @@ void DcrDecoder::decodeKodak65000(ByteStream &input, uint32 w, uint32 h, const u
         ushort16 value = pred[i & 1] += buf[i];
         if (value > 1023)
           ThrowRDE("DCR Decoder: Value out of bounds %d", value);
-        dest[x+i] = curve[value];
+        if(uncorrectedRawValues)
+          dest[x+i] = value;
+        else
+          mRaw->setWithLookUp(value, (uchar8*)&dest[x+i], &random);
       }
     }
   }

--- a/RawSpeed/DcrDecoder.h
+++ b/RawSpeed/DcrDecoder.h
@@ -39,9 +39,8 @@ public:
   virtual void decodeMetaDataInternal(CameraMetaData *meta);
 protected:
   TiffIFD *mRootIFD;
-  void decodeKodak65000(ByteStream &input, uint32 w, uint32 h, const ushort16 *curve);
+  void decodeKodak65000(ByteStream &input, uint32 w, uint32 h);
   void decodeKodak65000Segment(ByteStream &input, ushort16 *out, uint32 bsize);
-  ushort16 linear[1024];
 };
 
 } // namespace RawSpeed

--- a/RawSpeed/DcsDecoder.cpp
+++ b/RawSpeed/DcsDecoder.cpp
@@ -1,0 +1,100 @@
+#include "StdAfx.h"
+#include "DcsDecoder.h"
+
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2015 Pedro Côrte-Real
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+    http://www.klauspost.com
+*/
+
+namespace RawSpeed {
+
+DcsDecoder::DcsDecoder(TiffIFD *rootIFD, FileMap* file)  :
+    RawDecoder(file), mRootIFD(rootIFD) {
+  decoderVersion = 0;
+}
+
+DcsDecoder::~DcsDecoder(void) {
+}
+
+RawImage DcsDecoder::decodeRawInternal() {
+  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(IMAGEWIDTH);
+
+  if (data.size() < 1)
+    ThrowRDE("DCS Decoder: No image data found");
+
+  TiffIFD* raw = data[0];
+  uint32 width = raw->getEntry(IMAGEWIDTH)->getInt();
+  // Find the largest image in the file
+  for(uint32 i=1; i<data.size(); i++)
+    if(data[i]->getEntry(IMAGEWIDTH)->getInt() > width)
+      raw = data[i];
+
+  width = raw->getEntry(IMAGEWIDTH)->getInt();
+  uint32 height = raw->getEntry(IMAGELENGTH)->getInt();
+  uint32 off = raw->getEntry(STRIPOFFSETS)->getInt();
+  uint32 c2 = raw->getEntry(STRIPBYTECOUNTS)->getInt();
+
+  if (off > mFile->getSize())
+    ThrowRDE("DCR Decoder: Offset is out of bounds");
+
+  if (c2 > mFile->getSize() - off) {
+    mRaw->setError("Warning: byte count larger than file size, file probably truncated.");
+  }
+
+  mRaw->dim = iPoint2D(width, height);
+  mRaw->createData();
+  ByteStream input(mFile->getData(off), mFile->getSize() - off);
+
+  TiffEntry *linearization = mRootIFD->getEntryRecursive(GRAYRESPONSECURVE);
+  if (!linearization || linearization->count != 256 || linearization->type != TIFF_SHORT)
+    ThrowRDE("DCS Decoder: Couldn't find the linearization table");
+
+  if (uncorrectedRawValues)
+    Decode8BitRaw(input, width, height);
+  else
+    Decode8BitRaw(input, width, height, linearization->getShortArray());
+
+  return mRaw;
+}
+
+void DcsDecoder::checkSupportInternal(CameraMetaData *meta) {
+  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
+  if (data.empty())
+    ThrowRDE("DCS Support check: Model name not found");
+  string make = data[0]->getEntry(MAKE)->getString();
+  string model = data[0]->getEntry(MODEL)->getString();
+  this->checkCameraSupported(meta, make, model, "");
+}
+
+void DcsDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
+  vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
+
+  if (data.empty())
+    ThrowRDE("DCS Decoder: Model name found");
+  if (!data[0]->hasEntry(MAKE))
+    ThrowRDE("DCS Decoder: Make name not found");
+
+  string make = data[0]->getEntry(MAKE)->getString();
+  string model = data[0]->getEntry(MODEL)->getString();
+  setMetaData(meta, make, model, "", 0);
+}
+
+} // namespace RawSpeed

--- a/RawSpeed/DcsDecoder.cpp
+++ b/RawSpeed/DcsDecoder.cpp
@@ -67,10 +67,17 @@ RawImage DcsDecoder::decodeRawInternal() {
   if (!linearization || linearization->count != 256 || linearization->type != TIFF_SHORT)
     ThrowRDE("DCS Decoder: Couldn't find the linearization table");
 
-  if (uncorrectedRawValues)
-    Decode8BitRaw(input, width, height);
-  else
-    Decode8BitRaw(input, width, height, linearization->getShortArray());
+  if (!uncorrectedRawValues)
+    mRaw->setTable(linearization->getShortArray(), 256, true);
+
+  Decode8BitRaw(input, width, height);
+
+  // Set the table, if it should be needed later.
+  if (uncorrectedRawValues) {
+    mRaw->setTable(linearization->getShortArray(), 256, false);
+  } else {
+    mRaw->setTable(NULL);
+  }
 
   return mRaw;
 }

--- a/RawSpeed/DcsDecoder.h
+++ b/RawSpeed/DcsDecoder.h
@@ -1,0 +1,45 @@
+/*
+    RawSpeed - RAW file decoder.
+
+    Copyright (C) 2009-2014 Klaus Post
+    Copyright (C) 2014 Pedro Côrte-Real
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+    http://www.klauspost.com
+*/
+#ifndef DCS_DECODER_H
+#define DCS_DECODER_H
+
+#include "RawDecoder.h"
+
+namespace RawSpeed {
+
+class DcsDecoder :
+  public RawDecoder
+{
+public:
+  DcsDecoder(TiffIFD *rootIFD, FileMap* file);
+  virtual ~DcsDecoder(void);
+  virtual RawImage decodeRawInternal();
+  virtual void checkSupportInternal(CameraMetaData *meta);
+  virtual void decodeMetaDataInternal(CameraMetaData *meta);
+protected:
+  TiffIFD *mRootIFD;
+};
+
+} // namespace RawSpeed
+
+#endif

--- a/RawSpeed/KdcDecoder.cpp
+++ b/RawSpeed/KdcDecoder.cpp
@@ -35,6 +35,9 @@ KdcDecoder::~KdcDecoder(void) {
 }
 
 RawImage KdcDecoder::decodeRawInternal() {
+  if (!mRootIFD->hasEntryRecursive(COMPRESSION))
+    ThrowRDE("KDC Decoder: Couldn't find compression setting");
+
   int compression = mRootIFD->getEntryRecursive(COMPRESSION)->getInt();
   if (7 != compression)
     ThrowRDE("KDC Decoder: Unsupported compression %d", compression);
@@ -58,6 +61,9 @@ RawImage KdcDecoder::decodeRawInternal() {
   // Offset hardcoding gotten from dcraw
   if (hints.find("easyshare_offset_hack") != hints.end())
     off = off < 0x15000 ? 0x15000 : 0x17000;
+
+  if (off > mFile->getSize())
+    ThrowRDE("KDC Decoder: offset is out of bounds");
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();

--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -195,6 +195,31 @@ void RawDecoder::readUncompressedRaw(ByteStream &input, iPoint2D& size, iPoint2D
   }
 }
 
+void RawDecoder::Decode8BitRaw(ByteStream &input, uint32 w, uint32 h, const ushort16 *curve) {
+  uchar8* data = mRaw->getData();
+  uint32 pitch = mRaw->pitch;
+  const uchar8 *in = input.getData();
+  if (input.getRemainSize() < w*h) {
+    if ((uint32)input.getRemainSize() > w) {
+      h = input.getRemainSize() / w - 1;
+      mRaw->setError("Image truncated (file is too short)");
+    } else
+      ThrowIOE("Decode8BitRaw: Not enough data to decode a single line. Image file truncated.");
+  }
+  for (uint32 y = 0; y < h; y++) {
+    ushort16* dest = (ushort16*) & data[y*pitch];
+    for (uint32 x = 0 ; x < w; x += 1) {
+      if (curve)
+        dest[x] = curve[*in++];
+      else
+        dest[x] = *in++;
+    }
+  }
+}
+
+void RawDecoder::Decode8BitRaw(ByteStream &input, uint32 w, uint32 h) {
+  Decode8BitRaw(input, w, h, NULL);
+}
 
 void RawDecoder::Decode12BitRaw(ByteStream &input, uint32 w, uint32 h) {
   uchar8* data = mRaw->getData();

--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -195,7 +195,7 @@ void RawDecoder::readUncompressedRaw(ByteStream &input, iPoint2D& size, iPoint2D
   }
 }
 
-void RawDecoder::Decode8BitRaw(ByteStream &input, uint32 w, uint32 h, const ushort16 *curve) {
+void RawDecoder::Decode8BitRaw(ByteStream &input, uint32 w, uint32 h) {
   uchar8* data = mRaw->getData();
   uint32 pitch = mRaw->pitch;
   const uchar8 *in = input.getData();
@@ -206,19 +206,17 @@ void RawDecoder::Decode8BitRaw(ByteStream &input, uint32 w, uint32 h, const usho
     } else
       ThrowIOE("Decode8BitRaw: Not enough data to decode a single line. Image file truncated.");
   }
+
+  uint32 random = 0;
   for (uint32 y = 0; y < h; y++) {
     ushort16* dest = (ushort16*) & data[y*pitch];
     for (uint32 x = 0 ; x < w; x += 1) {
-      if (curve)
-        dest[x] = curve[*in++];
-      else
+      if (uncorrectedRawValues)
         dest[x] = *in++;
+      else
+        mRaw->setWithLookUp(*in++, (uchar8*)&dest[x], &random);
     }
   }
-}
-
-void RawDecoder::Decode8BitRaw(ByteStream &input, uint32 w, uint32 h) {
-  Decode8BitRaw(input, w, h, NULL);
 }
 
 void RawDecoder::Decode12BitRaw(ByteStream &input, uint32 w, uint32 h) {

--- a/RawSpeed/RawDecoder.h
+++ b/RawSpeed/RawDecoder.h
@@ -166,6 +166,11 @@ protected:
   /* order: Order of the bits - see Common.h for possibilities. */
   void readUncompressedRaw(ByteStream &input, iPoint2D& size, iPoint2D& offset, int inputPitch, int bitPerPixel, BitOrder order);
 
+  /* Faster versions for unpacking 8 bit data, curve is a 256 entry lookup table
+     to convert the 8 bit values to 16bit */
+  void Decode8BitRaw(ByteStream &input, uint32 w, uint32 h);
+  void Decode8BitRaw(ByteStream &input, uint32 w, uint32 h, const ushort16 *curve);
+
   /* Faster version for unpacking 12 bit LSB data */
   void Decode12BitRaw(ByteStream &input, uint32 w, uint32 h);
 

--- a/RawSpeed/RawDecoder.h
+++ b/RawSpeed/RawDecoder.h
@@ -166,10 +166,8 @@ protected:
   /* order: Order of the bits - see Common.h for possibilities. */
   void readUncompressedRaw(ByteStream &input, iPoint2D& size, iPoint2D& offset, int inputPitch, int bitPerPixel, BitOrder order);
 
-  /* Faster versions for unpacking 8 bit data, curve is a 256 entry lookup table
-     to convert the 8 bit values to 16bit */
+  /* Faster versions for unpacking 8 bit data */
   void Decode8BitRaw(ByteStream &input, uint32 w, uint32 h);
-  void Decode8BitRaw(ByteStream &input, uint32 w, uint32 h, const ushort16 *curve);
 
   /* Faster version for unpacking 12 bit LSB data */
   void Decode12BitRaw(ByteStream &input, uint32 w, uint32 h);

--- a/RawSpeed/TiffParser.cpp
+++ b/RawSpeed/TiffParser.cpp
@@ -133,6 +133,11 @@ RawDecoder* TiffParser::getDecoder() {
     for (vector<TiffIFD*>::iterator i = potentials.begin(); i != potentials.end(); ++i) {
       string make = (*i)->getEntry(MAKE)->getString();
       TrimSpaces(make);
+      string model = "";
+      if ((*i)->hasEntry(MODEL)) {
+        model = (*i)->getEntry(MODEL)->getString();
+        TrimSpaces(model);
+      }
       if (!make.compare("Canon")) {
         mRootIFD = NULL;
         return new Cr2Decoder(root, mInput);
@@ -181,7 +186,11 @@ RawDecoder* TiffParser::getDecoder() {
       }
       if (!make.compare("Kodak")) {
         mRootIFD = NULL;
-        return new DcrDecoder(root, mInput);
+        if (!model.compare("DCS560C"))
+          return new Cr2Decoder(root, mInput);
+        else
+          return new DcrDecoder(root, mInput);
+      }
       }
       if (!make.compare("EASTMAN KODAK COMPANY")) {
         mRootIFD = NULL;

--- a/RawSpeed/TiffParser.cpp
+++ b/RawSpeed/TiffParser.cpp
@@ -15,6 +15,7 @@
 #include "KdcDecoder.h"
 #include "ErfDecoder.h"
 #include "ThreefrDecoder.h"
+#include "DcsDecoder.h"
 
 /*
     RawSpeed - RAW file decoder.
@@ -191,6 +192,9 @@ RawDecoder* TiffParser::getDecoder() {
         else
           return new DcrDecoder(root, mInput);
       }
+      if (!make.compare("KODAK")) {
+        mRootIFD = NULL;
+        return new DcsDecoder(root, mInput);
       }
       if (!make.compare("EASTMAN KODAK COMPANY")) {
         mRootIFD = NULL;

--- a/RawSpeed/TiffTag.h
+++ b/RawSpeed/TiffTag.h
@@ -58,6 +58,8 @@ typedef enum {
   YRESOLUTION    = 0x011B,
   PLANARCONFIGURATION   = 0x011C,
 
+  GRAYRESPONSECURVE = 0x0123,
+
   T4OPTIONS                       = 0x0124,
   T6OPTIONS                       = 0x0125,
 

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7342,7 +7342,7 @@
 			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
+		<Crop x="3" y="0" width="-3" height="0"/>
 		<Sensor black="7" white="6664"/>
 	</Camera>
 	<Camera make="Kodak" model="DCS560C">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7334,6 +7334,20 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3700"/>
 	</Camera>
+	<Camera make="Kodak" model="DCS560C">
+		<ID make="Kodak" model="DCS560C">Kodak DCS560C</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="0" white="4095"/>
+		<Hints>
+			<Hint name="old_format" value=""/>
+		</Hints>
+	</Camera>
 	<Camera make="EASTMAN KODAK COMPANY" model="KODAK P880 ZOOM DIGITAL CAMERA">
 		<ID make="Kodak" model="P880">Kodak P880</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7334,6 +7334,17 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3700"/>
 	</Camera>
+	<Camera make="KODAK" model="DCS460D         FILE VERSION 3">
+		<ID make="Kodak" model="DCS460D">Kodak DCS460</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="7" white="6664"/>
+	</Camera>
 	<Camera make="Kodak" model="DCS560C">
 		<ID make="Kodak" model="DCS560C">Kodak DCS560C</ID>
 		<CFA width="2" height="2">
@@ -7347,6 +7358,17 @@
 		<Hints>
 			<Hint name="old_format" value=""/>
 		</Hints>
+	</Camera>
+	<Camera make="KODAK" model="EOSDCS1B        FILE VERSION 3">
+		<ID make="Kodak" model="EOS DCS 1">Kodak EOSDCS1</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="3" y="0" width="-3" height="0"/>
+		<Sensor black="19" white="7638"/>
 	</Camera>
 	<Camera make="EASTMAN KODAK COMPANY" model="KODAK P880 ZOOM DIGITAL CAMERA">
 		<ID make="Kodak" model="P880">Kodak P880</ID>


### PR DESCRIPTION
This adds support for three more Kodak DSLRs, one by reusing the D2000 support in Cr2Decoder and two others by adding a new decoder for an 8bit uncompressed format. While working on this I also fixed some safety bugs in the KDC and DCR decoders.
