### PR TITLE
ARW: support the new uncompressed format

### DIFF
--- a/RawSpeed/ArwDecoder.h
+++ b/RawSpeed/ArwDecoder.h
@@ -45,7 +45,7 @@ public:
 protected:
   void DecodeARW(ByteStream &input, uint32 w, uint32 h);
   void DecodeARW2(ByteStream &input, uint32 w, uint32 h, uint32 bpp);
-  void DecodeSR2(TiffIFD* raw);
+  void DecodeUncompressed(TiffIFD* raw);
   void GetWB();
   TiffIFD *mRootIFD;
   ByteStream *in;

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7356,6 +7356,9 @@
 		</CFA>
 		<Crop x="0" y="0" width="-60" height="0"/>
 		<Sensor black="511" white="16383"/>
+		<Hints>
+			<Hint name="sr2_format" value=""/>
+		</Hints>
 	</Camera>
 	<Camera make="Mamiya-OP Co.,Ltd." model="MAMIYA ZD">
 		<ID make="Mamiya" model="ZD">Mamiya ZD</ID>


### PR DESCRIPTION
The latest cameras have the option for a 16bit uncompressed (not even 14bit packed) format. The changes to support it are pretty minimal.
