### PR TITLE
RW2: enable zero_is_bad for all files

### DIFF
--- a/RawSpeed/Rw2Decoder.cpp
+++ b/RawSpeed/Rw2Decoder.cpp
@@ -131,10 +131,7 @@ void Rw2Decoder::decodeThreaded(RawDecoderThread * t) {
   int w = mRaw->dim.x / 14;
   uint32 y;
 
-  bool zero_is_bad = false;
-  map<string,string>::iterator zero_hint = hints.find("zero_is_bad");
-  if (zero_hint != hints.end())
-    zero_is_bad = true;
+  bool zero_is_bad = true;
 
   /* 9 + 1/7 bits per pixel */
   int skip = w * 14 * t->start_y * 9;

--- a/RawSpeed/Rw2Decoder.cpp
+++ b/RawSpeed/Rw2Decoder.cpp
@@ -132,6 +132,8 @@ void Rw2Decoder::decodeThreaded(RawDecoderThread * t) {
   uint32 y;
 
   bool zero_is_bad = true;
+  if (hints.find("zero_is_not_bad") != hints.end())
+    zero_is_bad = false;
 
   /* 9 + 1/7 bits per pixel */
   int skip = w * 14 * t->start_y * 9;


### PR DESCRIPTION
As discussed in issue #120 we can just enable zero_is_bad for all RW2 files as the format always uses this.
