### PR TITLE
Remove white balance override hint

### DIFF
--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -592,21 +592,6 @@ void RawDecoder::setMetaData(CameraMetaData *meta, string make, string model, st
       }
     }
   }
-
-  // Allow overriding the whitebalance. Values are R,G,B multipliers
-  // A hint could be:
-  // <Hint name="override_whitebalance" value="10,20,30"/>
-  if (cam->hints.find(string("override_whitebalance")) != cam->hints.end()) {
-    string rgb = cam->hints.find(string("override_whitebalance"))->second;
-    vector<string> v = split_string(rgb, ',');
-    if (v.size() != 3) {
-      mRaw->setError("Expected 3 values '10,20,30' as values for override_whitebalance hint.");
-    } else {
-      for (int i = 0; i < 3; i++) {
-        mRaw->metadata.wbCoeffs[i] = (float) atoi(v[i].c_str());
-      }
-    }
-  }
 }
 
 

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -133,9 +133,6 @@
 		</CFA>
 		<Crop x="48" y="6" width="0" height="-2"/>
 		<Sensor black="126" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="2093285,1000000,1055975"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="0" width="46"/>
 		</BlackAreas>
@@ -853,7 +850,6 @@
 		<Sensor black="96" white="4095"/>
 		<Hints>
 			<Hint name="old_format" value=""/>
-			<Hint name="override_whitebalance" value="1003807,1000000,2468898"/>
 		</Hints>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS-1D Mark II">
@@ -1025,9 +1021,6 @@
 		</CFA>
 		<Crop x="4" y="6" width="-52" height="-6"/>
 		<Sensor black="129" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="2185173,1000000,1342573"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="3294" width="50"/>
 		</BlackAreas>
@@ -1080,9 +1073,6 @@
 		</CFA>
 		<Crop x="12" y="6" width="-52" height="-2"/>
 		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="1757692,1000000,2071795"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="2326" width="50"/>
 			<Horizontal y="0" height="10"/>
@@ -1098,9 +1088,6 @@
 		</CFA>
 		<Crop x="12" y="6" width="-44" height="-2"/>
 		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="1984870,1000000,1237501"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="2632" width="40"/>
 			<Horizontal y="0" height="10"/>
@@ -1116,9 +1103,6 @@
 		</CFA>
 		<Crop x="44" y="12" width="-4" height="-4"/>
 		<Sensor black="128" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="2340268,1000000,1351293"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="0" width="40"/>
 			<Horizontal y="0" height="10"/>
@@ -1336,9 +1320,6 @@
 		</CFA>
 		<Crop x="12" y="6" width="-52" height="-2"/>
 		<Sensor black="129" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="2466639,1000000,1153626"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="2326" width="50"/>
 		</BlackAreas>
@@ -1353,9 +1334,6 @@
 		</CFA>
 		<Crop x="12" y="6" width="-44" height="-2"/>
 		<Sensor black="129" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="2168080,1000000,1356259"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="2632" width="40"/>
 			<Horizontal y="0" height="10"/>
@@ -1371,9 +1349,6 @@
 		</CFA>
 		<Crop x="12" y="6" width="-44" height="-2"/>
 		<Sensor black="129" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="2143041,1000000,1136598"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="2632" width="40"/>
 			<Horizontal y="0" height="10"/>
@@ -1389,9 +1364,6 @@
 		</CFA>
 		<Crop x="44" y="12" width="-4" height="-4"/>
 		<Sensor black="129" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="2279613,1000000,1245660"/>
-		</Hints>
 		<BlackAreas>
 			<Vertical x="0" width="40"/>
 			<Horizontal y="0" height="10"/>
@@ -1536,9 +1508,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="2000" height="1312"/>
 		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="960152,1000000,1041009"/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D1H">
 		<ID make="Nikon" model="D1H">Nikon D1H</ID>
@@ -7370,9 +7339,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4000"/>
-		<Hints>
-			<Hint name="override_whitebalance" value="12740092,10000000,11964914"/>
-		</Hints>
 	</Camera>
 	<Camera make="Creo/Leaf" model="Leaf Aptus 22(LF3779     )/Hasselblad H1">
 		<ID make="Leaf" model="Aptus 22">Leaf Aptus 22</ID>
@@ -7848,7 +7814,6 @@
 			<Hint name="filesize" value="6573120"/>
 			<Hint name="full_width" value="2672"/>
 			<Hint name="full_height" value="1968"/>
-			<Hint name="override_whitebalance" value="1564987,1000000,1710746"/>
 		</Hints>
 		<BlackAreas>
 			<Vertical x="2632" width="40"/>
@@ -7878,7 +7843,6 @@
 			<Hint name="filesize" value="7710960"/>
 			<Hint name="full_width" value="2888"/>
 			<Hint name="full_height" value="2136"/>
-			<Hint name="override_whitebalance" value="1582762,1000000,1718605"/>
 		</Hints>
 		<BlackAreas>
 			<Vertical x="0" width="40"/>
@@ -7895,7 +7859,6 @@
 			<Hint name="filesize" value="9219600"/>
 			<Hint name="full_width" value="3152"/>
 			<Hint name="full_height" value="2340"/>
-			<Hint name="override_whitebalance" value="1568679,1000000,1602855"/>
 		</Hints>
 		<BlackAreas>
 			<Vertical x="0" width="30"/>
@@ -7925,7 +7888,6 @@
 			<Hint name="filesize" value="10341600"/>
 			<Hint name="full_width" value="3336"/>
 			<Hint name="full_height" value="2480"/>
-			<Hint name="override_whitebalance" value="1524730,1000000,2009988"/>
 		</Hints>
 		<BlackAreas>
 			<Vertical x="3306" width="30"/>
@@ -7942,7 +7904,6 @@
 			<Hint name="filesize" value="10383120"/>
 			<Hint name="full_width" value="3344"/>
 			<Hint name="full_height" value="2484"/>
-			<Hint name="override_whitebalance" value="1593248,957204,1460876"/>
 		</Hints>
 		<BlackAreas>
 			<Vertical x="0" width="30"/>
@@ -7959,7 +7920,6 @@
 			<Hint name="filesize" value="12945240"/>
 			<Hint name="full_width" value="3736"/>
 			<Hint name="full_height" value="2772"/>
-			<Hint name="override_whitebalance" value="1838080,1000000,1556674"/>
 		</Hints>
 		<BlackAreas>
 			<Vertical x="3686" width="50"/>
@@ -7976,7 +7936,6 @@
 			<Hint name="filesize" value="15636240"/>
 			<Hint name="full_width" value="4104"/>
 			<Hint name="full_height" value="3048"/>
-			<Hint name="override_whitebalance" value="2110416,1000000,1770211"/>
 		</Hints>
 		<BlackAreas>
 			<Vertical x="0" width="45"/>
@@ -7993,7 +7952,6 @@
 			<Hint name="filesize" value="15467760"/>
 			<Hint name="full_width" value="3720"/>
 			<Hint name="full_height" value="2772"/>
-			<Hint name="override_whitebalance" value="1614148,979180,2115417"/>
 		</Hints>
 		<BlackAreas>
 			<Vertical x="3690" width="30"/>


### PR DESCRIPTION
This didn't turn out to be a good idea. A good whitebalance fallback can be calculated from the camera matrix so there's no need to keep hardcoding these here.
