### PR TITLE
CFA: add a way to create a CFA from dcraw filters

### DIFF
--- a/RawSpeed/ColorFilterArray.h
+++ b/RawSpeed/ColorFilterArray.h
@@ -49,6 +49,7 @@ public:
   ColorFilterArray(const ColorFilterArray& other );
   ColorFilterArray& operator= (const ColorFilterArray& other);
   ColorFilterArray(iPoint2D size);
+  ColorFilterArray(const uint32 dcrawFilters);
   virtual ~ColorFilterArray(void);
   virtual void setSize(iPoint2D size);
   void setColorAt(iPoint2D pos, CFAColor c);
@@ -61,6 +62,7 @@ public:
   virtual std::string asString();
   static std::string colorToString(CFAColor c);
   uint32 toDcrawColor(CFAColor c);
+  CFAColor toRawspeedColor(uint32 dcrawColor);
   iPoint2D size;
 protected:
   CFAColor *cfa;


### PR DESCRIPTION
This is useful to use the rawspeed code to calculate the dcraw filters of a cropped image. I've used it in darktable to remove some simplistic code that didn't work for all filter types.
