### PR TITLE
ARW: support for the Sony F828

### DIFF
--- a/RawSpeed/ArwDecoder.h
+++ b/RawSpeed/ArwDecoder.h
@@ -46,6 +46,7 @@ protected:
   void DecodeARW(ByteStream &input, uint32 w, uint32 h);
   void DecodeARW2(ByteStream &input, uint32 w, uint32 h, uint32 bpp);
   void DecodeUncompressed(TiffIFD* raw);
+  void SonyDecrypt(uint32 *buffer, uint32 len, uint32 key);
   void GetWB();
   TiffIFD *mRootIFD;
   ByteStream *in;

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7103,6 +7103,20 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
 	</Camera>
+	<Camera make="SONY" model="DSC-F828">
+		<ID make="Sony" model="DSC-F828">Sony DSC-F828</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">YELLOW</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="5" y="0" width="-67" height="0"/>
+		<Sensor black="495" white="16383"/>
+		<Hints>
+			<Hint name="srf_format" value=""/>
+		</Hints>
+	</Camera>
 	<Camera make="SONY" model="DSC-R1">
 		<ID make="Sony" model="DSC-R1">Sony DSC-R1</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
The Sony F828 has a specific SRF format that's weird in that it uses the sony "encryption" usually used for the metadata for the image itself. Reuse the "decrypt" code we already had to make this work.
