### PR TITLE
4bayer support

### DIFF
--- a/RawSpeed/CrwDecoder.cpp
+++ b/RawSpeed/CrwDecoder.cpp
@@ -134,21 +134,12 @@ void CrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   if(mRootIFD->hasEntryRecursive((CiffTag)0x102c)) {
     CiffEntry *entry = mRootIFD->getEntryRecursive((CiffTag)0x102c);
     if (entry->type == CIFF_SHORT && entry->getShort() > 512) {
-      /* G1 */
-
+      // G1/Pro90 CYGM pattern
       const ushort16 *data = entry->getShortArray();
-
-      // RGB? (second green level looks bogus)
-      float cam_mul[4];
-      for(int c = 0; c < 4; c++)
-      {
-        cam_mul[c ^ 2] = (float) data[60 + c];
-      }
-
-      const float green = cam_mul[1];
-      mRaw->metadata.wbCoeffs[0] = cam_mul[0] / green;
-      mRaw->metadata.wbCoeffs[1] = 1.0f;
-      mRaw->metadata.wbCoeffs[2] = cam_mul[2] / green;
+      mRaw->metadata.wbCoeffs[0] = (float) data[62];
+      mRaw->metadata.wbCoeffs[1] = (float) data[63];
+      mRaw->metadata.wbCoeffs[2] = (float) data[60];
+      mRaw->metadata.wbCoeffs[3] = (float) data[61];
     } else if (entry->type == CIFF_SHORT) {
       /* G2, S30, S40 */
 

--- a/RawSpeed/RawImage.cpp
+++ b/RawSpeed/RawImage.cpp
@@ -63,6 +63,7 @@ ImageMetaData::ImageMetaData(void) {
   wbCoeffs[0] = NAN;
   wbCoeffs[1] = NAN;
   wbCoeffs[2] = NAN;
+  wbCoeffs[3] = NAN;
 }
 
 RawImageData::~RawImageData(void) {

--- a/RawSpeed/RawImage.h
+++ b/RawSpeed/RawImage.h
@@ -73,7 +73,7 @@ public:
   double pixelAspectRatio;
 
   // White balance coefficients of the image
-  float wbCoeffs[3];
+  float wbCoeffs[4];
 
   // How many pixels far down the left edge and far up the right edge the image 
   // corners are when the image is rotated 45 degrees in Fuji rotated sensors.

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1036,10 +1036,10 @@
 	<Camera make="Canon" model="Canon PowerShot G1">
 		<ID make="Canon" model="PowerShot G1">Canon PowerShot G1</ID>
 		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
+			<Color x="0" y="0">FUJI_GREEN</Color>
+			<Color x="1" y="0">MAGENTA</Color>
+			<Color x="0" y="1">YELLOW</Color>
+			<Color x="1" y="1">CYAN</Color>
 		</CFA>
 		<Crop x="4" y="8" width="-52" height="-2"/>
 		<Sensor black="31" white="1023"/>
@@ -2390,10 +2390,10 @@
 	<Camera make="NIKON" model="E5700" decoder_version="4">
 		<ID make="Nikon" model="E5700">Nikon E5700</ID>
 		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
+			<Color x="0" y="0">FUJI_GREEN</Color>
+			<Color x="1" y="0">MAGENTA</Color>
+			<Color x="0" y="1">YELLOW</Color>
+			<Color x="1" y="1">CYAN</Color>
 		</CFA>
 		<Crop x="0" y="0" width="2576" height="1924"/>
 		<Sensor black="0" white="4095"/>


### PR DESCRIPTION
Add support for cameras with CYGM/RGBE sensors by fixing their CFAs and returning 4 values for WB coeffs.
