### PR TITLE
DNG fixes motivated by x3f_extract utility

### DIFF
--- a/RawSpeed/DngDecoder.cpp
+++ b/RawSpeed/DngDecoder.cpp
@@ -535,6 +535,9 @@ void DngDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
 
 /* DNG Images are assumed to be decodable unless explicitly set so */
 void DngDecoder::checkSupportInternal(CameraMetaData *meta) {
+  // We set this, since DNG's are not explicitly added.
+  failOnUnknown = FALSE;
+
   if (!(mRootIFD->hasEntryRecursive(MAKE) && mRootIFD->hasEntryRecursive(MODEL))) {
     // Check "Unique Camera Model" instead, uses this for both make + model.
     if (mRootIFD->hasEntryRecursive(UNIQUECAMERAMODEL)) {
@@ -548,9 +551,6 @@ void DngDecoder::checkSupportInternal(CameraMetaData *meta) {
   }
 
   vector<TiffIFD*> data = mRootIFD->getIFDsWithTag(MODEL);
-
-  // We set this, since DNG's are not explicitly added. 
-  failOnUnknown = FALSE;
   string make = data[0]->getEntry(MAKE)->getString();
   string model = data[0]->getEntry(MODEL)->getString();
   this->checkCameraSupported(meta, make, model, "dng");

--- a/RawSpeed/TiffEntry.cpp
+++ b/RawSpeed/TiffEntry.cpp
@@ -123,7 +123,7 @@ unsigned short TiffEntry::getShort() {
 }
 
 const uint32* TiffEntry::getIntArray() {
-  if (type != TIFF_LONG && type != TIFF_SLONG && type != TIFF_RATIONAL && type != TIFF_SRATIONAL && type != TIFF_UNDEFINED )
+  if (type != TIFF_LONG && type != TIFF_SLONG && type != TIFF_RATIONAL && type != TIFF_SRATIONAL && type != TIFF_UNDEFINED && type != TIFF_OFFSET)
     ThrowTPE("TIFF, getIntArray: Wrong type 0x%x encountered. Expected Long", type);
   return (uint32*)&data[0];
 }

--- a/RawSpeed/TiffEntryBE.cpp
+++ b/RawSpeed/TiffEntryBE.cpp
@@ -93,7 +93,7 @@ unsigned short TiffEntryBE::getShort() {
 }
 
 const uint32* TiffEntryBE::getIntArray() {
-  if (!(type == TIFF_LONG || type == TIFF_SLONG || type == TIFF_UNDEFINED || type == TIFF_RATIONAL ||  type == TIFF_SRATIONAL))
+  if (!(type == TIFF_LONG || type == TIFF_SLONG || type == TIFF_UNDEFINED || type == TIFF_RATIONAL || type == TIFF_SRATIONAL || type == TIFF_OFFSET))
     ThrowTPE("TIFF, getIntArray: Wrong type 0x%x encountered. Expected Int", type);
   if (own_data)
     return (uint32*)own_data;


### PR DESCRIPTION
Recently some DNGs generated by the x3f_extract utility[1] were failing. It turned out to be two issues. First DNGs without make/model were not accepted without a <Camera> entry. Second the DNGs used type 13 for SubIFD offsets and getIntArray() was not accepting that like getInt() already did. This fixes both and makes those DNGs load apparently fine.

[1] https://github.com/kalpanika/x3f
