### PR TITLE
Sync some leak/warnings fixes from darktable

### DIFF
--- a/RawSpeed/LJpegDecompressor.cpp
+++ b/RawSpeed/LJpegDecompressor.cpp
@@ -504,9 +504,9 @@ void LJpegDecompressor::createBigTable(HuffmanTable *htbl) {
 
     if (rv == 16) {
       if (mDNGCompatible)
-        htbl->bigTable[i] = (-32768 << 8) | (16 + l);
+        htbl->bigTable[i] = (-(32768 << 8)) | (16 + l);
       else
-        htbl->bigTable[i] = (-32768 << 8) | l;
+        htbl->bigTable[i] = (-(32768 << 8)) | l;
       continue;
     }
 

--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -276,11 +276,11 @@ void NefDecoder::readCoolpixMangledRaw(ByteStream &input, iPoint2D& size, iPoint
   uint32 y = offset.y;
   h = MIN(h + (uint32)offset.y, (uint32)mRaw->dim.y);
   w *= cpp;
-  BitPumpMSB32 *in = new BitPumpMSB32(&input);
+  BitPumpMSB32 in(&input);
   for (; y < h; y++) {
     ushort16* dest = (ushort16*) & data[offset.x*sizeof(ushort16)*cpp+y*outPitch];
     for (uint32 x = 0 ; x < w; x++) {
-      dest[x] =  in->getBits(12);
+      dest[x] = in.getBits(12);
     }
   }
 }
@@ -308,17 +308,17 @@ void NefDecoder::readCoolpixSplitRaw(ByteStream &input, iPoint2D& size, iPoint2D
   h = MIN(h + (uint32)offset.y, (uint32)mRaw->dim.y);
   w *= cpp;
   h /= 2;
-  BitPumpMSB *in = new BitPumpMSB(&input);
+  BitPumpMSB in(&input);
   for (; y < h; y++) {
     ushort16* dest = (ushort16*) & data[offset.x*sizeof(ushort16)*cpp+y*2*outPitch];
     for (uint32 x = 0 ; x < w; x++) {
-      dest[x] =  in->getBits(12);
+      dest[x] =  in.getBits(12);
     }
   }
   for (y = offset.y; y < h; y++) {
     ushort16* dest = (ushort16*) & data[offset.x*sizeof(ushort16)*cpp+(y*2+1)*outPitch];
     for (uint32 x = 0 ; x < w; x++) {
-      dest[x] =  in->getBits(12);
+      dest[x] =  in.getBits(12);
     }
   }
 }

--- a/RawSpeed/X3fDecoder.cpp
+++ b/RawSpeed/X3fDecoder.cpp
@@ -360,7 +360,7 @@ void X3fDecoder::decodeThreaded( RawDecoderThread* t )
     }
     
     /* We have a weird prediction which is actually more appropriate for a CFA image */
-    BitPumpMSB *bits = new BitPumpMSB(mFile->getData(plane_offset[i]), mFile->getSize()-plane_offset[i]);
+    BitPumpMSB bits(mFile->getData(plane_offset[i]), mFile->getSize()-plane_offset[i]);
     /* Initialize predictors */
     int pred_up[4];
     int pred_left[2];
@@ -369,22 +369,22 @@ void X3fDecoder::decodeThreaded( RawDecoderThread* t )
 
     for (int y = 0; y < dim.y; y++) {
       ushort16* dst = (ushort16*)mRaw->getData(0, y << subs) + i;
-      int diff1= SigmaDecode(bits);
-      int diff2 = SigmaDecode(bits);
+      int diff1= SigmaDecode(&bits);
+      int diff2 = SigmaDecode(&bits);
       dst[0] = pred_left[0] = pred_up[y & 1] = pred_up[y & 1] + diff1;
       dst[3<<subs] = pred_left[1] = pred_up[(y & 1) + 2] = pred_up[(y & 1) + 2] + diff2;
       dst += 6<<subs;
       // We decode two pixels every loop
       for (int x = 2; x < dim.x; x += 2) {
-        int diff1 = SigmaDecode(bits);
-        int diff2 = SigmaDecode(bits);
+        int diff1 = SigmaDecode(&bits);
+        int diff2 = SigmaDecode(&bits);
         dst[0] = pred_left[0] = pred_left[0] + diff1;
         dst[3<<subs] = pred_left[1] = pred_left[1] + diff2;
         dst += 6<<subs;
       }
       // If plane is larger than image, skip that number of pixels.
       for (int i = 0; i < skipX; i++)
-        SigmaSkipOne(bits);
+        SigmaSkipOne(&bits);
     }
     return;
   }


### PR DESCRIPTION
Code comes from these darktable commits:

```
commit bf70218ba5e46ebe4dd7a95faa177ef15a3ff33a
Author: Roman Lebedev <lebedev.ri@gmail.com>
Date:   Sun Nov 29 21:30:52 2015 +0300

    rawspeed: LJpegDecompressor::createBigTable(): UB: shifting a negative signed value

    Supposedly, this is the correct way to fix it, but apparently i do not
    have a correct sample that uses that code...

    clang 3.7+ warning: shifting a negative signed value is undefined [-Wshift-negative-value]
```

```
commit baa1aa9c48f320ea9c73a821733b9d1892d07583
Author: Roman Lebedev <lebedev.ri@gmail.com>
Date:   Sat Jan 2 19:24:06 2016 +0300

    Rawspeed: fix some BitPumpMSB* leaks
```

```
commit baa1aa9c48f320ea9c73a821733b9d1892d07583
Author: Roman Lebedev <lebedev.ri@gmail.com>
Date:   Sat Jan 2 19:24:06 2016 +0300

    Rawspeed: fix some BitPumpMSB* leaks
```
