### PR TITLE
Canon EOS 80D: add support for mRaw and sRaw formats

### DIFF
--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -176,6 +176,7 @@ RawImage Cr2Decoder::decodeRawInternal() {
   // Fix for Canon 6D mRaw, which has flipped width & height for some part of the image
   // In that case, we swap width and height, since this is the correct dimension
   bool flipDims = false;
+  bool wrappedCr2Slices = false;
   if (raw->hasEntry((TiffTag)0xc6c5)) {
     ushort16 ss = raw->getEntry((TiffTag)0xc6c5)->getInt();
     // sRaw
@@ -183,6 +184,19 @@ RawImage Cr2Decoder::decodeRawInternal() {
       mRaw->dim.x /= 3;
       mRaw->setCpp(3);
       mRaw->isCFA = false;
+      // Fix for Canon 80D mraw format.
+      // In that format, the frame (as read by getSOF()) is 4032x3402, while the
+      // real image should be 4536x3024 (where the full vertical slices in
+      // the frame "wrap around" the image.
+      if (hints.find("wrapped_cr2_slices") != hints.end() && raw->hasEntry(IMAGEWIDTH) && raw->hasEntry(IMAGELENGTH)) {
+        wrappedCr2Slices = true;
+        int w = raw->getEntry(IMAGEWIDTH)->getInt();
+        int h = raw->getEntry(IMAGELENGTH)->getInt();
+        if (w * h != mRaw->dim.x * mRaw->dim.y) {
+          ThrowRDE("CR2 Decoder: Wrapped slices don't match image size");
+        }
+        mRaw->dim = iPoint2D(w, h);
+      }
     }
     flipDims = mRaw->dim.x < mRaw->dim.y;
     if (flipDims) {
@@ -217,6 +231,7 @@ RawImage Cr2Decoder::decodeRawInternal() {
       l.mUseBigtable = true;
       l.mCanonFlipDim = flipDims;
       l.mCanonDoubleHeight = doubleHeight;
+      l.mWrappedCr2Slices = wrappedCr2Slices;
       l.startDecoder(slice.offset, slice.count, 0, offY);
     } catch (RawDecoderException &e) {
       if (i == 0)

--- a/RawSpeed/LJpegDecompressor.h
+++ b/RawSpeed/LJpegDecompressor.h
@@ -173,6 +173,7 @@ public:
   bool mUseBigtable;    // Use only for large images
   bool mCanonFlipDim;   // Fix Canon 6D mRaw where width/height is flipped
   bool mCanonDoubleHeight; // Fix Canon double height on 4 components (EOS 5DS R)
+  bool mWrappedCr2Slices; // Fix Canon 80D mRaw where the slices are wrapped
   virtual void addSlices(vector<int> slices) {slicesW=slices;};  // CR2 slices.
 protected:
   virtual void parseSOF(SOFInfo* i);

--- a/RawSpeed/LJpegPlain.cpp
+++ b/RawSpeed/LJpegPlain.cpp
@@ -252,6 +252,14 @@ void LJpegPlain::decodeScanLeftGeneric() {
   x = maxSuperH;
   pixInSlice -= maxSuperH;
 
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  uint32 oldSkipY = skipY;
+  if (mWrappedCr2Slices)
+    skipY = 0;
+
   uint32 cw = (frame.w - skipX);
   for (uint32 y = 0;y < (frame.h - skipY);y += maxSuperV) {
     for (; x < cw ; x += maxSuperH) {
@@ -302,6 +310,8 @@ void LJpegPlain::decodeScanLeftGeneric() {
     predict = dest;
     x = 0;
   }
+  if (mWrappedCr2Slices)
+    skipY = oldSkipY;
   delete[] imagePos;
   delete[] sliceWidth;
 }
@@ -400,6 +410,14 @@ void LJpegPlain::decodeScanLeft4_2_0() {
   x = 2;
   pixInSlice -= 2;
 
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  uint32 oldSkipY = skipY;
+  if (mWrappedCr2Slices)
+    skipY = 0;
+
   uint32 cw = (frame.w - skipX);
   for (uint32 y = 0;y < (frame.h - skipY);y += 2) {
     for (; x < cw ; x += 2) {
@@ -445,6 +463,8 @@ void LJpegPlain::decodeScanLeft4_2_0() {
 
     x = 0;
   }
+  if (mWrappedCr2Slices)
+    skipY = oldSkipY;
 }
 
 void LJpegPlain::decodeScanLeft4_2_2() {
@@ -528,6 +548,14 @@ void LJpegPlain::decodeScanLeft4_2_2() {
   x = 2;
   pixInSlice -= 2;
 
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  uint32 oldSkipY = skipY;
+  if (mWrappedCr2Slices)
+    skipY = 0;
+
   uint32 cw = (frame.w - skipX);
   for (uint32 y = 0;y < (frame.h - skipY);y++) {
     for (; x < cw ; x += 2) {
@@ -567,6 +595,8 @@ void LJpegPlain::decodeScanLeft4_2_2() {
     // Check if we are still within the file.
     bits->checkPos();
   }
+  if (mWrappedCr2Slices)
+    skipY = oldSkipY;
 }
 
 #undef COMPS

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -374,19 +374,32 @@
 				<Horizontal y="0" height="33"/>
 			</BlackAreas>
 		</Camera>
-		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" supported="no">
+		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" supported="yes"> <!-- "mRaw" -->
 			<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
-			<Crop x="0" y="0" width="0" height="0"/>
-			<Sensor black="0" white="14338"/>
+			<Crop x="28" y="10" width="0" height="0"/>
+			<Sensor black="0" white="48816" iso_list="320 640 1250 2500 5000"/>
+			<Sensor black="0" white="51936" iso_list="160"/>
+			<Sensor black="0" white="55680" iso_list="400 500 800 1000 1600 2000 3200 4000 6400 12800 16000 25600"/>
+			<Sensor black="0" white="55688" iso_list="8000 10000"/>
+			<Sensor black="0" white="58832" iso_list="100 125 200 250"/>
 			<Hints>
 				<Hint name="sraw_new" value=""/>
 				<Hint name="invert_sraw_wb" value=""/>
+				<Hint name="wrapped_cr2_slices" value=""/>
 			</Hints>
 		</Camera>
-		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw2" supported="no">
+		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw2"> <!-- "sRaw" -->
 			<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
 			<Crop x="0" y="0" width="0" height="0"/>
-			<Sensor black="0" white="14338"/>
+			<Sensor black="0" white="48468" iso_list="2500"/>
+			<Sensor black="0" white="48488" iso_list="1250"/>
+			<Sensor black="0" white="48492" iso_list="320"/>
+			<Sensor black="0" white="48496" iso_list="640"/>
+			<Sensor black="0" white="48588" iso_list="5000"/>
+			<Sensor black="0" white="51932" iso_list="160"/>
+			<Sensor black="0" white="55680" iso_list="400 500 800 1000 1600 2000 3200 4000 6400 12800 16000 25600"/>
+			<Sensor black="0" white="55688" iso_list="8000 10000"/>
+			<Sensor black="0" white="58832" iso_list="100 125 200 250"/>
 			<Hints>
 				<Hint name="sraw_new" value=""/>
 				<Hint name="invert_sraw_wb" value=""/>


### PR DESCRIPTION
New decoder hint: wrapped_cr2_slices

In the EOS 80D mRaw format, the frame size is 4032x3402, while the real image size is 4536x3024 (see also http://lclevy.free.fr/cr2/). This is achieved by wrapping the slices.
