### PR TITLE
Sync in changes from darktable. Fixes #158. Fixes #161. Fixes #162.

### DIFF
--- a/RawSpeed/ArwDecoder.cpp
+++ b/RawSpeed/ArwDecoder.cpp
@@ -158,7 +158,7 @@ RawImage ArwDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
 
-  ushort16 curve[0x4001];
+  ushort16 *curve = new ushort16[0x4001];
   TiffEntry *c = raw->getEntry(SONY_CURVE);
   uint32 sony_curve[] = { 0, 0, 0, 0, 0, 4095 };
 
@@ -202,6 +202,8 @@ RawImage ArwDecoder::decodeRawInternal() {
   } else {
     mRaw->setTable(NULL);
   }
+
+  delete[] curve;
 
   return mRaw;
 }

--- a/RawSpeed/BitPumpJPEG.h
+++ b/RawSpeed/BitPumpJPEG.h
@@ -50,7 +50,8 @@ public:
  __inline uint32 peekBitsNoFill( uint32 nbits )
  {
    int shift = mLeft-nbits;
-   uint32 ret = *(uint32*)&current_buffer[shift>>3];
+   uint32 ret;
+   memcpy(&ret, (uint32*)&current_buffer[shift>>3], sizeof(uint32));
    ret >>= shift & 7;
    return ret & ((1 << nbits) - 1);
  }

--- a/RawSpeed/BitPumpMSB.h
+++ b/RawSpeed/BitPumpMSB.h
@@ -86,7 +86,8 @@ __inline uint32 getBitNoFill() {
 
 __inline uint32 peekByteNoFill() {
   int shift = mLeft-8;
-  uint32 ret = *(uint32*)&current_buffer[shift>>3];
+  uint32 ret;
+  memcpy(&ret, (uint32*)&current_buffer[shift>>3], sizeof(uint32));
   ret >>= shift & 7;
   return ret & 0xff;
 }

--- a/RawSpeed/BitPumpMSB.h
+++ b/RawSpeed/BitPumpMSB.h
@@ -50,7 +50,8 @@ public:
  __inline uint32 peekBitsNoFill( uint32 nbits )
  {
    int shift = mLeft-nbits;
-   uint32 ret = *(uint32*)&current_buffer[shift>>3];
+   uint32 ret;
+   memcpy(&ret, (uint32*)&current_buffer[shift>>3], sizeof(uint32));
    ret >>= shift & 7;
    return ret & ((1 << nbits) - 1);
  }

--- a/RawSpeed/BitPumpPlain.cpp
+++ b/RawSpeed/BitPumpPlain.cpp
@@ -45,7 +45,9 @@ uint32 BitPumpPlain::getBit() throw() {
 }
 
 uint32 BitPumpPlain::getBits(uint32 nbits) throw() {
-  uint32 v = *(uint32*) & buffer[off>>3] >> (off & 7) & ((1 << nbits) - 1);
+  uint32 v;
+  memcpy(&v, (uint32*) & buffer[off>>3], sizeof(uint32));
+  v = v >> (off & 7) & ((1 << nbits) - 1);
   off += nbits;
   return v;
 }

--- a/RawSpeed/CameraMetaData.cpp
+++ b/RawSpeed/CameraMetaData.cpp
@@ -77,6 +77,18 @@ Camera* CameraMetaData::getCamera(string make, string model, string mode) {
   return cameras[id];
 }
 
+Camera* CameraMetaData::getCamera(string make, string model) {
+  string id = getId(make, model, "");
+
+  // do a prefix match, i.e. the make and model match, but not mode.
+  std::map<string,Camera*>::iterator iter = cameras.lower_bound(id);
+
+  if (iter == cameras.find(id))
+    return NULL;
+
+  return cameras[iter->first];
+}
+
 bool CameraMetaData::hasCamera(string make, string model, string mode) {
   string id = getId(make, model, mode);
   if (cameras.end() == cameras.find(id))

--- a/RawSpeed/CameraMetaData.cpp
+++ b/RawSpeed/CameraMetaData.cpp
@@ -56,15 +56,29 @@ CameraMetaData::~CameraMetaData(void) {
   }
 }
 
+static inline string getId(string make, string model, string mode)
+{
+  TrimSpaces(make);
+  TrimSpaces(model);
+  TrimSpaces(mode);
+
+  return string(make).append(model).append(mode);
+}
+
+static inline string getId(Camera* cam)
+{
+  return getId(cam->make, cam->model, cam->mode);
+}
+
 Camera* CameraMetaData::getCamera(string make, string model, string mode) {
-  string id = string(make).append(model).append(mode);
+  string id = getId(make, model, mode);
   if (cameras.end() == cameras.find(id))
     return NULL;
   return cameras[id];
 }
 
 bool CameraMetaData::hasCamera(string make, string model, string mode) {
-  string id = string(make).append(model).append(mode);
+  string id = getId(make, model, mode);
   if (cameras.end() == cameras.find(id))
     return FALSE;
   return TRUE;
@@ -82,7 +96,7 @@ bool CameraMetaData::hasChdkCamera(uint32 filesize) {
 
 bool CameraMetaData::addCamera( Camera* cam )
 {
-  string id = string(cam->make).append(cam->model).append(cam->mode);
+  string id = getId(cam);
   if (cameras.end() != cameras.find(id)) {
     writeLog(DEBUG_PRIO_WARNING, "CameraMetaData: Duplicate entry found for camera: %s %s, Skipping!\n", cam->make.c_str(), cam->model.c_str());
     delete(cam);

--- a/RawSpeed/CameraMetaData.h
+++ b/RawSpeed/CameraMetaData.h
@@ -36,7 +36,13 @@ public:
   virtual ~CameraMetaData(void);
   map<string,Camera*> cameras;
   map<uint32,Camera*> chdkCameras;
+
+  // searches for camera with given make + model + mode
   Camera* getCamera(string make, string model, string mode);
+
+  // searches for camera with given make + model, with ANY mode
+  Camera* getCamera(string make, string model);
+
   bool hasCamera(string make, string model, string mode);
   Camera* getChdkCamera(uint32 filesize);
   bool hasChdkCamera(uint32 filesize);

--- a/RawSpeed/Common.cpp
+++ b/RawSpeed/Common.cpp
@@ -35,9 +35,13 @@ int macosx_version()
   char str[256];
   size_t strsize = sizeof(str);
   if (0 == ver && sysctlbyname("kern.osrelease", str, &strsize, NULL, 0) == 0) {
-    // sysctl is major.minor.path
-    *strchr(str, '.') = '\0';
-    ver = 0x1000 + strtol(str, NULL, 10)*10;
+    // kern.osrelease is a string formated as "Major.Minor.Patch"
+    if (memchr(str, '\0', strsize) != NULL) {
+      int major, minor, patch;
+      if (sscanf(str, "%d.%d.%d", &major, &minor, &patch) == 3) {
+        ver = 0x1000 + major*10;
+      }
+    }
   }
   return ver;
 }

--- a/RawSpeed/Common.cpp
+++ b/RawSpeed/Common.cpp
@@ -24,14 +24,20 @@
 
 
 #if defined(__APPLE__)
-#include <CoreServices/CoreServices.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <stdlib.h>
+#include <string.h>
 
 int macosx_version()
 {
-  SInt32 gestalt_version;
   static int ver = 0; // cached
-  if (0 == ver && (Gestalt(gestaltSystemVersion, &gestalt_version) == noErr)) {
-    ver = gestalt_version;
+  char str[256];
+  size_t strsize = sizeof(str);
+  if (0 == ver && sysctlbyname("kern.osrelease", str, &strsize, NULL, 0) == 0) {
+    // sysctl is major.minor.path
+    *strchr(str, '.') = '\0';
+    ver = 0x1000 + strtol(str, NULL, 10)*10;
   }
   return ver;
 }

--- a/RawSpeed/Common.h
+++ b/RawSpeed/Common.h
@@ -57,13 +57,6 @@ typedef char* LPCWSTR;
 #endif
 #endif // __unix__
 
-#ifndef TRUE
-#define TRUE 1
-#endif
-#ifndef FALSE
-#define FALSE 0
-#endif
-
 #ifndef UINT32_MAX
 #define UINT32_MAX 0xffffffff
 #endif

--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -187,6 +187,7 @@ RawImage Cr2Decoder::decodeRawInternal() {
       mRaw->dim.x /= 3;
       mRaw->setCpp(3);
       mRaw->isCFA = false;
+
       // Fix for Canon 80D mraw format.
       // In that format, the frame (as read by getSOF()) is 4032x3402, while the
       // real image should be 4536x3024 (where the full vertical slices in

--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -179,6 +179,7 @@ RawImage Cr2Decoder::decodeRawInternal() {
   // Fix for Canon 6D mRaw, which has flipped width & height for some part of the image
   // In that case, we swap width and height, since this is the correct dimension
   bool flipDims = false;
+  bool wrappedCr2Slices = false;
   if (raw->hasEntry((TiffTag)0xc6c5)) {
     ushort16 ss = raw->getEntry((TiffTag)0xc6c5)->getInt();
     // sRaw
@@ -186,6 +187,19 @@ RawImage Cr2Decoder::decodeRawInternal() {
       mRaw->dim.x /= 3;
       mRaw->setCpp(3);
       mRaw->isCFA = false;
+      // Fix for Canon 80D mraw format.
+      // In that format, the frame (as read by getSOF()) is 4032x3402, while the
+      // real image should be 4536x3024 (where the full vertical slices in
+      // the frame "wrap around" the image.
+      if (hints.find("wrapped_cr2_slices") != hints.end() && raw->hasEntry(IMAGEWIDTH) && raw->hasEntry(IMAGELENGTH)) {
+        wrappedCr2Slices = true;
+        int w = raw->getEntry(IMAGEWIDTH)->getInt();
+        int h = raw->getEntry(IMAGELENGTH)->getInt();
+        if (w * h != mRaw->dim.x * mRaw->dim.y) {
+          ThrowRDE("CR2 Decoder: Wrapped slices don't match image size");
+        }
+        mRaw->dim = iPoint2D(w, h);
+      }
     }
     flipDims = mRaw->dim.x < mRaw->dim.y;
     if (flipDims) {
@@ -220,6 +234,7 @@ RawImage Cr2Decoder::decodeRawInternal() {
       l->mUseBigtable = true;
       l->mCanonFlipDim = flipDims;
       l->mCanonDoubleHeight = doubleHeight;
+      l->mWrappedCr2Slices = wrappedCr2Slices;
       l->startDecoder(slice.offset, slice.count, 0, offY);
       delete l;
     } catch (RawDecoderException &e) {

--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -29,7 +29,7 @@ namespace RawSpeed {
 
 Cr2Decoder::Cr2Decoder(TiffIFD *rootIFD, FileMap* file) :
     RawDecoder(file), mRootIFD(rootIFD) {
-  decoderVersion = 6;
+  decoderVersion = 7;
 }
 
 Cr2Decoder::~Cr2Decoder(void) {

--- a/RawSpeed/Cr2Decoder.cpp
+++ b/RawSpeed/Cr2Decoder.cpp
@@ -75,12 +75,14 @@ RawImage Cr2Decoder::decodeRawInternal() {
     }
 
     mRaw->createData();
-    LJpegPlain l(mFile, mRaw);
+    LJpegPlain *l = new LJpegPlain(mFile, mRaw);
     try {
-      l.startDecoder(off, mFile->getSize()-off, 0, 0);
+      l->startDecoder(off, mFile->getSize()-off, 0, 0);
     } catch (IOException& e) {
       mRaw->setError(e.what());
     }
+
+    delete l;
 
     if(hints.find("double_line_ljpeg") != hints.end()) {
       // We now have a double width half height image we need to convert to the
@@ -144,8 +146,9 @@ RawImage Cr2Decoder::decodeRawInternal() {
       slice.offset = offsets[0].getInt();
       slice.count = counts[0].getInt();
       SOFInfo sof;
-      LJpegPlain l(mFile, mRaw);
-      l.getSOF(&sof, slice.offset, slice.count);
+      LJpegPlain *l = new LJpegPlain(mFile, mRaw);
+      l->getSOF(&sof, slice.offset, slice.count);
+      delete l;
       slice.w = sof.w * sof.cps;
       slice.h = sof.h;
       if (sof.cps == 4 && slice.w > slice.h * 4) {
@@ -212,12 +215,13 @@ RawImage Cr2Decoder::decodeRawInternal() {
   for (uint32 i = 0; i < slices.size(); i++) {
     Cr2Slice slice = slices[i];
     try {
-      LJpegPlain l(mFile, mRaw);
-      l.addSlices(s_width);
-      l.mUseBigtable = true;
-      l.mCanonFlipDim = flipDims;
-      l.mCanonDoubleHeight = doubleHeight;
-      l.startDecoder(slice.offset, slice.count, 0, offY);
+      LJpegPlain *l = new LJpegPlain(mFile, mRaw);
+      l->addSlices(s_width);
+      l->mUseBigtable = true;
+      l->mCanonFlipDim = flipDims;
+      l->mCanonDoubleHeight = doubleHeight;
+      l->startDecoder(slice.offset, slice.count, 0, offY);
+      delete l;
     } catch (RawDecoderException &e) {
       if (i == 0)
         throw;

--- a/RawSpeed/CrwDecoder.cpp
+++ b/RawSpeed/CrwDecoder.cpp
@@ -1,5 +1,6 @@
 #include "StdAfx.h"
 #include "CrwDecoder.h"
+#include <cmath>
 
 /*
     RawSpeed - RAW file decoder.
@@ -85,6 +86,23 @@ void CrwDecoder::checkSupportInternal(CameraMetaData *meta) {
   this->checkCameraSupported(meta, make, model, "");
 }
 
+// based on exiftool's Image::ExifTool::Canon::CanonEv
+static float canonEv(const long in) {
+  // remove sign
+  long val = abs(in);
+  // remove fraction
+  float frac = static_cast<float>(val & 0x1f);
+  val -= long(frac);
+  // convert 1/3 (0x0c) and 2/3 (0x14) codes
+  if (frac == 0x0c) {
+    frac = 32.0f / 3;
+  }
+  else if (frac == 0x14) {
+    frac = 64.0f / 3;
+  }
+  return copysignf((val + frac) / 32.0f, in);
+}
+
 void CrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   int iso = 0;
   mRaw->cfa.setCFA(iPoint2D(2,2), CFA_RED, CFA_GREEN, CFA_GREEN2, CFA_BLUE);
@@ -97,6 +115,15 @@ void CrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   string make = makemodel[0];
   string model = makemodel[1];
   string mode = "";
+
+  if (mRootIFD->hasEntryRecursive(CIFF_SHOTINFO)) {
+    CiffEntry *shot_info = mRootIFD->getEntryRecursive(CIFF_SHOTINFO);
+    if (shot_info->type == CIFF_SHORT && shot_info->count >= 2) {
+      // os << exp(canonEv(value.toLong()) * log(2.0)) * 100.0 / 32.0;
+      ushort16 iso_index = shot_info->getShort(2);
+      iso = expf(canonEv((long)iso_index) * logf(2.0)) * 100.0f / 32.0f;
+    }
+  }
 
   // Fetch the white balance
   try{

--- a/RawSpeed/DngDecoder.cpp
+++ b/RawSpeed/DngDecoder.cpp
@@ -466,6 +466,8 @@ void DngDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
     Camera *cam = meta->getCamera(make, model, "dng");
     if (!cam) //Also look for non-DNG cameras in case it's a converted file
       cam = meta->getCamera(make, model, "");
+    if (!cam) // Worst case scenario, look for any such camera.
+      cam = meta->getCamera(make, model);
     if (cam) {
       mRaw->metadata.canonical_make = cam->canonical_make;
       mRaw->metadata.canonical_model = cam->canonical_model;

--- a/RawSpeed/DngDecoderSlices.cpp
+++ b/RawSpeed/DngDecoderSlices.cpp
@@ -100,7 +100,7 @@ static void init_source (j_decompress_ptr cinfo) {}
 static boolean fill_input_buffer (j_decompress_ptr cinfo)
 {
   struct jpeg_source_mgr* src = (struct jpeg_source_mgr*) cinfo->src;
-  return !!src->bytes_in_buffer;
+  return (boolean)!!src->bytes_in_buffer;
 }
 static void skip_input_data (j_decompress_ptr cinfo, long num_bytes)
 {

--- a/RawSpeed/LJpegDecompressor.h
+++ b/RawSpeed/LJpegDecompressor.h
@@ -173,6 +173,7 @@ public:
   bool mUseBigtable;    // Use only for large images
   bool mCanonFlipDim;   // Fix Canon 6D mRaw where width/height is flipped
   bool mCanonDoubleHeight; // Fix Canon double height on 4 components (EOS 5DS R)
+  bool mWrappedCr2Slices; // Fix Canon 80D mRaw where the slices are wrapped
   virtual void addSlices(vector<int> slices) {slicesW=slices;};  // CR2 slices.
 protected:
   virtual void parseSOF(SOFInfo* i);

--- a/RawSpeed/LJpegPlain.cpp
+++ b/RawSpeed/LJpegPlain.cpp
@@ -252,8 +252,16 @@ void LJpegPlain::decodeScanLeftGeneric() {
   x = maxSuperH;
   pixInSlice -= maxSuperH;
 
+
   uint32 cw = (frame.w - skipX);
-  for (uint32 y = 0;y < (frame.h - skipY);y += maxSuperV) {
+  uint32 ch = (frame.h - skipY);
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  if (mWrappedCr2Slices)
+    ch = frame.h;
+  for (uint32 y = 0;y < ch;y += maxSuperV) {
     for (; x < cw ; x += maxSuperH) {
 
       if (0 == pixInSlice) { // Next slice
@@ -401,7 +409,14 @@ void LJpegPlain::decodeScanLeft4_2_0() {
   pixInSlice -= 2;
 
   uint32 cw = (frame.w - skipX);
-  for (uint32 y = 0;y < (frame.h - skipY);y += 2) {
+  uint32 ch = (frame.h - skipY);
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  if (mWrappedCr2Slices)
+    ch = frame.h;
+  for (uint32 y = 0;y < ch;y += 2) {
     for (; x < cw ; x += 2) {
 
       if (0 == pixInSlice) { // Next slice
@@ -529,7 +544,14 @@ void LJpegPlain::decodeScanLeft4_2_2() {
   pixInSlice -= 2;
 
   uint32 cw = (frame.w - skipX);
-  for (uint32 y = 0;y < (frame.h - skipY);y++) {
+  uint32 ch = (frame.h - skipY);
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  if (mWrappedCr2Slices)
+    ch = frame.h;
+  for (uint32 y = 0;y < ch;y++) {
     for (; x < cw ; x += 2) {
 
       if (0 == pixInSlice) { // Next slice
@@ -625,7 +647,14 @@ void LJpegPlain::decodeScanLeft2Comps() {
   uint32 pixInSlice = slice_width[0] - 1;  // Skip first pixel
 
   uint32 x = 1;                            // Skip first pixels on first line.
-  for (uint32 y = 0;y < (frame.h - skipY);y++) {
+  uint32 ch = (frame.h - skipY);
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  if (mWrappedCr2Slices)
+    ch = frame.h;
+  for (uint32 y = 0;y < ch;y++) {
     for (; x < cw ; x++) {
       int diff = HuffDecode(dctbl1);
       p1 += diff;
@@ -721,8 +750,15 @@ void LJpegPlain::decodeScanLeft3Comps() {
 
   uint32 cw = (frame.w - skipX);
   uint32 x = 1;                            // Skip first pixels on first line.
+  uint32 ch = (frame.h - skipY);
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  if (mWrappedCr2Slices)
+    ch = frame.h;
 
-  for (uint32 y = 0;y < (frame.h - skipY);y++) {
+  for (uint32 y = 0;y < ch;y++) {
     for (; x < cw ; x++) {
       p1 += HuffDecode(dctbl1);
       *dest++ = (ushort16)p1;
@@ -833,7 +869,14 @@ void LJpegPlain::decodeScanLeft4Comps() {
   if (mCanonDoubleHeight)
     skipY = frame.h >> 1;
 
-  for (uint32 y = 0;y < (frame.h - skipY);y++) {
+  uint32 ch = (frame.h - skipY);
+  // Fix for Canon 80D mraw format.
+  // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
+  // Consequently, the slices in `frame` wrap around (this is taken care of by
+  // `offset`) and must be decoded fully (without skipY) to fill the image
+  if (mWrappedCr2Slices)
+    ch = frame.h;
+  for (uint32 y = 0;y < ch;y++) {
     for (; x < cw ; x++) {
       p1 += HuffDecode(dctbl1);
       *dest++ = (ushort16)p1;

--- a/RawSpeed/LJpegPlain.cpp
+++ b/RawSpeed/LJpegPlain.cpp
@@ -255,12 +255,14 @@ void LJpegPlain::decodeScanLeftGeneric() {
 
   uint32 cw = (frame.w - skipX);
   uint32 ch = (frame.h - skipY);
+
   // Fix for Canon 80D mraw format.
   // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
   // Consequently, the slices in `frame` wrap around (this is taken care of by
   // `offset`) and must be decoded fully (without skipY) to fill the image
   if (mWrappedCr2Slices)
     ch = frame.h;
+
   for (uint32 y = 0;y < ch;y += maxSuperV) {
     for (; x < cw ; x += maxSuperH) {
 
@@ -410,12 +412,14 @@ void LJpegPlain::decodeScanLeft4_2_0() {
 
   uint32 cw = (frame.w - skipX);
   uint32 ch = (frame.h - skipY);
+
   // Fix for Canon 80D mraw format.
   // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
   // Consequently, the slices in `frame` wrap around (this is taken care of by
   // `offset`) and must be decoded fully (without skipY) to fill the image
   if (mWrappedCr2Slices)
     ch = frame.h;
+
   for (uint32 y = 0;y < ch;y += 2) {
     for (; x < cw ; x += 2) {
 
@@ -545,12 +549,14 @@ void LJpegPlain::decodeScanLeft4_2_2() {
 
   uint32 cw = (frame.w - skipX);
   uint32 ch = (frame.h - skipY);
+
   // Fix for Canon 80D mraw format.
   // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
   // Consequently, the slices in `frame` wrap around (this is taken care of by
   // `offset`) and must be decoded fully (without skipY) to fill the image
   if (mWrappedCr2Slices)
     ch = frame.h;
+
   for (uint32 y = 0;y < ch;y++) {
     for (; x < cw ; x += 2) {
 
@@ -648,12 +654,14 @@ void LJpegPlain::decodeScanLeft2Comps() {
 
   uint32 x = 1;                            // Skip first pixels on first line.
   uint32 ch = (frame.h - skipY);
+
   // Fix for Canon 80D mraw format.
   // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
   // Consequently, the slices in `frame` wrap around (this is taken care of by
   // `offset`) and must be decoded fully (without skipY) to fill the image
   if (mWrappedCr2Slices)
     ch = frame.h;
+
   for (uint32 y = 0;y < ch;y++) {
     for (; x < cw ; x++) {
       int diff = HuffDecode(dctbl1);
@@ -751,6 +759,7 @@ void LJpegPlain::decodeScanLeft3Comps() {
   uint32 cw = (frame.w - skipX);
   uint32 x = 1;                            // Skip first pixels on first line.
   uint32 ch = (frame.h - skipY);
+
   // Fix for Canon 80D mraw format.
   // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
   // Consequently, the slices in `frame` wrap around (this is taken care of by
@@ -870,12 +879,14 @@ void LJpegPlain::decodeScanLeft4Comps() {
     skipY = frame.h >> 1;
 
   uint32 ch = (frame.h - skipY);
+
   // Fix for Canon 80D mraw format.
   // In that format, `frame` is 4032x3402, while `mRaw` is 4536x3024.
   // Consequently, the slices in `frame` wrap around (this is taken care of by
   // `offset`) and must be decoded fully (without skipY) to fill the image
   if (mWrappedCr2Slices)
     ch = frame.h;
+
   for (uint32 y = 0;y < ch;y++) {
     for (; x < cw ; x++) {
       p1 += HuffDecode(dctbl1);

--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -573,7 +573,7 @@ void NefDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
 
   if (white != 65536)
     mRaw->whitePoint = white;
-  if (black >= 0 && hints.find(string("nikon_override_auto_black")) == hints.end())
+  if (black != -1)
     mRaw->blackLevel = black;
 }
 

--- a/RawSpeed/NefDecoder.cpp
+++ b/RawSpeed/NefDecoder.cpp
@@ -108,17 +108,18 @@ RawImage NefDecoder::decodeRawInternal() {
   }
 
   try {
-    NikonDecompressor decompressor(mFile, mRaw);
-    decompressor.uncorrectedRawValues = uncorrectedRawValues;
+    NikonDecompressor* decompressor = new NikonDecompressor(mFile, mRaw);
+    decompressor->uncorrectedRawValues = uncorrectedRawValues;
     ByteStream* metastream;
     if (getHostEndianness() == data[0]->endian)
       metastream = new ByteStream(meta->getData(), meta->count);
     else
       metastream = new ByteStreamSwap(meta->getData(), meta->count);
 
-    decompressor.DecompressNikon(metastream, width, height, bitPerPixel, offsets->getInt(), counts->getInt());
+    decompressor->DecompressNikon(metastream, width, height, bitPerPixel, offsets->getInt(), counts->getInt());
 
     delete metastream;
+    delete decompressor;
   } catch (IOException &e) {
     mRaw->setError(e.what());
     // Let's ignore it, it may have delivered somewhat useful data.

--- a/RawSpeed/NikonDecompressor.cpp
+++ b/RawSpeed/NikonDecompressor.cpp
@@ -91,8 +91,6 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
   }
   initTable(huffSelect);
 
-  mRaw->whitePoint = curve[_max-1];
-  mRaw->blackLevel = curve[0];
   if (!uncorrectedRawValues) {
     mRaw->setTable(curve, _max, true);
   }

--- a/RawSpeed/RawDecoder.cpp
+++ b/RawSpeed/RawDecoder.cpp
@@ -542,7 +542,11 @@ void RawDecoder::setMetaData(CameraMetaData *meta, string make, string model, st
   Camera *cam = meta->getCamera(make, model, mode);
   if (!cam) {
     writeLog(DEBUG_PRIO_INFO, "ISO:%d\n", iso_speed);
-    writeLog(DEBUG_PRIO_WARNING, "Unable to find camera in database: %s %s %s\nPlease upload file to ftp.rawstudio.org, thanks!\n", make.c_str(), model.c_str(), mode.c_str());
+    writeLog(DEBUG_PRIO_WARNING, "Unable to find camera in database: '%s' '%s' '%s'\nPlease upload file to ftp.rawstudio.org, thanks!\n", make.c_str(), model.c_str(), mode.c_str());
+
+    if (failOnUnknown)
+      ThrowRDE("Camera '%s' '%s', mode '%s' not supported, and not allowed to guess. Sorry.", make.c_str(), model.c_str(), mode.c_str());
+
     return;
   }
 

--- a/RawSpeed/Rw2Decoder.cpp
+++ b/RawSpeed/Rw2Decoder.cpp
@@ -103,9 +103,9 @@ RawImage Rw2Decoder::decodeRawInternal() {
   }
   // Read blacklevels
   if (raw->hasEntry((TiffTag)0x1c) && raw->hasEntry((TiffTag)0x1d) && raw->hasEntry((TiffTag)0x1e)) {
-    mRaw->blackLevelSeparate[0] = raw->getEntry((TiffTag)0x1c)->getInt() + 15;
-    mRaw->blackLevelSeparate[1] = mRaw->blackLevelSeparate[2] = raw->getEntry((TiffTag)0x1d)->getInt() + 15;
-    mRaw->blackLevelSeparate[3] = raw->getEntry((TiffTag)0x1e)->getInt() + 15;
+    mRaw->blackLevelSeparate[0] = mRaw->blackLevelSeparate[3] = raw->getEntry((TiffTag)0x1d)->getInt() + 15;
+    mRaw->blackLevelSeparate[1] = raw->getEntry((TiffTag)0x1e)->getInt() + 15;
+    mRaw->blackLevelSeparate[2] = raw->getEntry((TiffTag)0x1c)->getInt() + 15;
   }
 
   // Read WB levels

--- a/RawSpeed/TiffEntry.cpp
+++ b/RawSpeed/TiffEntry.cpp
@@ -41,11 +41,13 @@ TiffEntry::TiffEntry(FileMap* f, uint32 offset, uint32 up_offset) {
 
   const uchar8 *temp_data = (const uchar8 *)f->getData(offset, 8);
   tag = (TiffTag) get2LE(temp_data, 0);
-  type = (TiffDataType) get2LE(temp_data, 2);
+  const ushort16 numType = get2LE(temp_data, 2);
   count = get4LE(temp_data,4);
 
-  if (type > 13)
-    ThrowTPE("Error reading TIFF structure. Unknown Type 0x%x encountered.", type);
+  if (numType > 13)
+    ThrowTPE("Error reading TIFF structure. Unknown Type 0x%x encountered.", numType);
+
+  type = (TiffDataType) numType;
 
   bytesize = (uint64)count << datashifts[type];
   if (bytesize > UINT32_MAX)

--- a/RawSpeed/TiffEntryBE.cpp
+++ b/RawSpeed/TiffEntryBE.cpp
@@ -33,11 +33,13 @@ TiffEntryBE::TiffEntryBE(FileMap* f, uint32 offset, uint32 up_offset) {
 
   const uchar8 *temp_data = f->getData(offset, 8);
   tag = (TiffTag) get2BE(temp_data, 0);
-  type = (TiffDataType) get2BE(temp_data, 2);
+  const ushort16 numType = (TiffDataType) get2BE(temp_data, 2);
   count = get4BE(temp_data,4);
 
-  if (type > 13)
-    ThrowTPE("Error reading TIFF structure. Unknown Type 0x%x encountered.", type);
+  if (numType > 13)
+    ThrowTPE("Error reading TIFF structure. Unknown Type 0x%x encountered.", numType);
+
+  type = (TiffDataType) numType;
 
   bytesize = (uint64)count << datashifts[type];
   if (bytesize > UINT32_MAX)

--- a/RawSpeed/TiffIFD.cpp
+++ b/RawSpeed/TiffIFD.cpp
@@ -126,8 +126,7 @@ TiffIFD* TiffIFD::parseDngPrivateData(TiffEntry *t) {
   */
   uint32 size = t->count;
   const uchar8 *data = t->getData();
-  string id((const char*)data);
-  if (0 != id.compare("Adobe"))
+  if (0 != memcmp(data, "Adobe", 6))
     ThrowTPE("Not Adobe Private data");
 
   data+=6;

--- a/RawSpeed/X3fDecoder.cpp
+++ b/RawSpeed/X3fDecoder.cpp
@@ -89,7 +89,7 @@ void X3fDecoder::decodeMetaDataInternal( CameraMetaData *meta )
 //
 // If the name is read, it will return true, and the make/model
 // will be available in camera_make/camera_model members.
-boolean X3fDecoder::readName() {
+bool X3fDecoder::readName() {
   if (camera_make.length() != 0 && camera_model.length() != 0) {
     return true;
   }

--- a/RawSpeed/X3fDecoder.h
+++ b/RawSpeed/X3fDecoder.h
@@ -55,7 +55,7 @@ protected:
   int SigmaDecode(BitPumpMSB *bits);
   string getIdAsString(ByteStream *bytes);
   void SigmaSkipOne(BitPumpMSB *bits);
-  boolean readName();
+  bool readName();
   X3fImage *curr_image;
   int pred[3];
   uint32 plane_sizes[3];

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1747,7 +1747,7 @@
 			<Hint name="wb_offset" value="142"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D100" mode="12bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D100" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D100">Nikon D100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -1758,7 +1758,7 @@
 		<Crop x="2" y="0" width="3030" height="2024"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D100" mode="12bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D100" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D100">Nikon D100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -1769,7 +1769,7 @@
 		<Crop x="2" y="0" width="3030" height="2024"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1" mode="12bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D1" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D1">Nikon D1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -1783,7 +1783,7 @@
 			<Hint name="nikon_wb_adjustment" value="true"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1" mode="12bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D1" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D1">Nikon D1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -1797,7 +1797,7 @@
 			<Hint name="nikon_wb_adjustment" value="true"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D1H">Nikon D1H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -1808,7 +1808,7 @@
 		<Crop x="0" y="0" width="2012" height="1324"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D1H">Nikon D1H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -1819,7 +1819,7 @@
 		<Crop x="0" y="0" width="2012" height="1324"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1X" mode="12bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D1X" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D1X">Nikon D1X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -1833,7 +1833,7 @@
 			<Hint name="pixel_aspect_ratio" value="0.5"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1X" mode="12bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D1X" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D1X">Nikon D1X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -1979,7 +1979,7 @@
 		<Crop x="2" y="0" width="4282" height="2844"/>
 		<Sensor black="0" white="4096"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -1990,7 +1990,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="16384"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2205,7 +2205,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D4">Nikon D4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2216,7 +2216,7 @@
 		<Crop x="2" y="0" width="-50" height="0"/>
 		<Sensor black="0" white="16383"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D4">Nikon D4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2305,7 +2305,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2319,7 +2319,7 @@
 			<Vertical x="4984" width="8"/>
 		</BlackAreas>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2405,7 +2405,7 @@
 		<Crop x="0" y="0" width="-46" height="0"/>
 		<Sensor black="0" white="4096"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-compressed" decoder_version="2">
+	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-compressed" decoder_version="2" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D3100">Nikon D3100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -2416,7 +2416,7 @@
 		<Crop x="8" y="2" width="-24" height="-2"/>
 		<Sensor black="0" white="16383"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-uncompressed" decoder_version="2">
+	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-uncompressed" decoder_version="2" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D3100">Nikon D3100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -2615,7 +2615,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="12bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D5200">Nikon D5200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2626,7 +2626,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4096"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="12bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D5200">Nikon D5200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2815,7 +2815,7 @@
 		<Crop x="0" y="0" width="-50" height="0"/>
 		<Sensor black="0" white="3880"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D70" mode="12bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D70" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D70">Nikon D70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -2826,7 +2826,7 @@
 		<Crop x="0" y="0" width="3038" height="2014"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D70" mode="12bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D70" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D70">Nikon D70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -2859,7 +2859,7 @@
 		<Crop x="2" y="0" width="4282" height="2844"/>
 		<Sensor black="0" white="3972"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D700">Nikon D700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2870,7 +2870,7 @@
 		<Crop x="2" y="0" width="4282" height="2844"/>
 		<Sensor black="0" white="16383"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D700">Nikon D700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3037,7 +3037,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D70s" mode="12bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D70s" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D70s">Nikon D70s</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3048,7 +3048,7 @@
 		<Crop x="0" y="0" width="3040" height="2014"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D70s" mode="12bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D70s" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D70s">Nikon D70s</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3361,7 +3361,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" mode="12bit-compressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 J3">Nikon 1 J3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3372,7 +3372,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" mode="12bit-uncompressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 J3">Nikon 1 J3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3383,7 +3383,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-compressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 J4">Nikon 1 J4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3397,7 +3397,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-uncompressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 J4">Nikon 1 J4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3450,7 +3450,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="3300"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" mode="12bit-compressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 S2">Nikon 1 S2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3464,7 +3464,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" mode="12bit-uncompressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 S2">Nikon 1 S2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3489,7 +3489,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="3300"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" mode="12bit-compressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 V2">Nikon 1 V2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3500,7 +3500,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" mode="12bit-uncompressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 V2">Nikon 1 V2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3539,7 +3539,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" mode="12bit-compressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 AW1">Nikon 1 AW1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3550,7 +3550,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" mode="12bit-uncompressed" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="1 AW1">Nikon 1 AW1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3561,7 +3561,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON" model="E5400" mode="12bit-compressed" decoder_version="3">
+	<Camera make="NIKON" model="E5400" mode="12bit-compressed" decoder_version="3" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="E5400">Nikon E5400</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3575,7 +3575,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E5400" mode="12bit-uncompressed" decoder_version="3">
+	<Camera make="NIKON" model="E5400" mode="12bit-uncompressed" decoder_version="3" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="E5400">Nikon E5400</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3589,7 +3589,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E5700" mode="12bit-compressed" decoder_version="4">
+	<Camera make="NIKON" model="E5700" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="E5700">Nikon E5700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">FUJI_GREEN</Color>
@@ -3603,7 +3603,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E5700" mode="12bit-uncompressed" decoder_version="4">
+	<Camera make="NIKON" model="E5700" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="E5700">Nikon E5700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">FUJI_GREEN</Color>
@@ -3617,7 +3617,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E8400" mode="12bit-compressed" decoder_version="3">
+	<Camera make="NIKON" model="E8400" mode="12bit-compressed" decoder_version="3" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="E8400">Nikon E8400</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3631,7 +3631,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E8400" mode="12bit-uncompressed" decoder_version="3">
+	<Camera make="NIKON" model="E8400" mode="12bit-uncompressed" decoder_version="3" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="E8400">Nikon E8400</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3682,7 +3682,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="200" white="3800"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="12bit-compressed">
+	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix A">Nikon Coolpix A</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3693,7 +3693,7 @@
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="12bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix A">Nikon Coolpix A</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3704,7 +3704,7 @@
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-compressed" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-compressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3719,7 +3719,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-uncompressed" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-uncompressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3734,7 +3734,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7000" mode="12bit-compressed" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P7000" mode="12bit-compressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix P7000">Nikon Coolpix P7000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3751,7 +3751,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7000" mode="12bit-uncompressed" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P7000" mode="12bit-uncompressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix P7000">Nikon Coolpix P7000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3768,7 +3768,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-compressed" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-compressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix P7100">Nikon Coolpix P7100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3785,7 +3785,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-uncompressed" decoder_version="1">
+	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-uncompressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix P7100">Nikon Coolpix P7100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3832,7 +3832,7 @@
 			<Hint name="real_bpp" value="16"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E8800" mode="12bit-compressed" decoder_version="3">
+	<Camera make="NIKON" model="E8800" mode="12bit-compressed" decoder_version="3" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix E8800">Nikon Coolpix E8800</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -3846,7 +3846,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E8800" mode="12bit-uncompressed" decoder_version="3">
+	<Camera make="NIKON" model="E8800" mode="12bit-uncompressed" decoder_version="3" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Coolpix E8800">Nikon Coolpix E8800</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -661,7 +661,12 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="74" y="40" width="0" height="-2"/>
-		<Sensor black="2048" white="16383"/>
+		<Sensor black="2048" white="15000"/>
+		<Sensor black="2047" white="15000" iso_list="50 100 125 200 250 16000"/>
+		<Sensor black="2047" white="13100" iso_list="160"/>
+		<Sensor black="2047" white="13000" iso_list="320"/>
+		<Sensor black="2048" white="13000" iso_list="640 1250 2500 5000 10000 20000"/>
+		<Sensor black="2048" white="16000" iso_list="51200 102400"/>
 		<BlackAreas>
 			<Vertical x="0" width="68"/>
 			<Horizontal y="2" height="36"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1957,7 +1957,7 @@
 		<Crop x="2" y="0" width="4282" height="2844"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3" mode="12bit-compressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D3" mode="12bit-compressed">
 		<ID make="Nikon" model="D3">Nikon D3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -1966,9 +1966,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="4282" height="2844"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3972"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3" mode="12bit-uncompressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D3" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D3">Nikon D3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -1977,7 +1977,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="4282" height="2844"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3972"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -5104,6 +5104,34 @@
 			<Alias>DMC-G70</Alias>
 		</Aliases>
 	</Camera>
+	<Camera make="Panasonic" model="DMC-G8">
+		<ID make="Panasonic" model="DMC-G8">Panasonic DMC-G8</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-208" height="0"/>
+		<Sensor black="143" white="4095"/>
+		<Aliases>
+			<Alias>DMC-G80</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-G8" mode="4:3">
+		<ID make="Panasonic" model="DMC-G8">Panasonic DMC-G8</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-208" height="0"/>
+		<Sensor black="143" white="4095"/>
+		<Aliases>
+			<Alias>DMC-G80</Alias>
+		</Aliases>
+	</Camera>
 	<Camera make="Panasonic" model = "DMC-GF3">
 		<ID make="Panasonic" model="DMC-GF3">Panasonic DMC-GF3</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2184,7 +2184,7 @@
 		<Crop x="0" y="0" width="3898" height="2610"/>
 		<Sensor black="0" white="4096"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3200" mode="14bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D3200" mode="12bit-compressed">
 		<ID make="Nikon" model="D3200">Nikon D3200</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2193,40 +2193,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-48" height="0"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3200" mode="14bit-uncompressed">
-		<ID make="Nikon" model="D3200">Nikon D3200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-48" height="0"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3200" mode="12bit-compressed" supported="no">
-		<ID make="Nikon" model="D3200">Nikon D3200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-48" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3200" mode="12bit-uncompressed" supported="no">
-		<ID make="Nikon" model="D3200">Nikon D3200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-48" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3300" mode="12bit-compressed">
 		<ID make="Nikon" model="D3300">Nikon D3300</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2205,7 +2205,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-compressed">
 		<ID make="Nikon" model="D4">Nikon D4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2214,9 +2214,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15520"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-uncompressed">
 		<ID make="Nikon" model="D4">Nikon D4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2225,9 +2225,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15520"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="12bit-compressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="12bit-compressed">
 		<ID make="Nikon" model="D4">Nikon D4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2236,9 +2236,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="12bit-uncompressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D4">Nikon D4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2247,7 +2247,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="14bit-compressed">
 		<ID make="Nikon" model="D5">Nikon D5</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1819,7 +1819,7 @@
 		<Crop x="0" y="0" width="2012" height="1324"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1X" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D1X" mode="12bit-compressed">
 		<ID make="Nikon" model="D1X">Nikon D1X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -1833,7 +1833,7 @@
 			<Hint name="pixel_aspect_ratio" value="0.5"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1X" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D1X" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D1X">Nikon D1X</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -4612,6 +4612,28 @@
 		<Crop x="0" y="0" width="-128" height="0"/>
 		<Sensor black="150" white="3956"/>
 	</Camera>
+	<Camera make="Panasonic" model="DMC-FZ300">
+		<ID make="Panasonic" model="DMC-FZ300">Panasonic DMC-FZ300</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-128" height="0"/>
+		<Sensor black="143" white="4095"/>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-FZ300" mode="4:3">
+		<ID make="Panasonic" model="DMC-FZ300">Panasonic DMC-FZ300</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-128" height="0"/>
+		<Sensor black="143" white="4095"/>
+	</Camera>
 	<Camera make="Panasonic" model = "DMC-G1">
 		<ID make="Panasonic" model="DMC-G1">Panasonic DMC-G1</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2345,7 +2345,7 @@
 			<Vertical x="4984" width="8"/>
 		</BlackAreas>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="12bit-compressed">
 		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2354,12 +2354,12 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 		<BlackAreas>
 			<Vertical x="4984" width="8"/>
 		</BlackAreas>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="12bit-uncompressed">
 		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2368,7 +2368,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 		<BlackAreas>
 			<Vertical x="4984" width="8"/>
 		</BlackAreas>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3336,7 +3336,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 AW1">Nikon 1 AW1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3346,17 +3346,7 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="1 AW1">Nikon 1 AW1</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
+		<Sensor black="0" white="3300" iso_list="160"/>
 	</Camera>
 	<Camera make="NIKON" model="E5400" mode="12bit-uncompressed" decoder_version="3">
 		<ID make="Nikon" model="E5400">Nikon E5400</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3394,7 +3394,7 @@
 		<Crop x="0" y="0" width="4310" height="2868"/>
 		<Sensor black="0" white="3767"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J1" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J1" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 J1">Nikon 1 J1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3403,7 +3403,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="-2"/>
-		<Sensor black="0" white="0"/>
+		<Sensor black="0" white="3300"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J2" decoder_version="4">
 		<ID make="Nikon" model="1 J2">Nikon 1 J2</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -384,19 +384,32 @@
 				<Horizontal y="0" height="33"/>
 			</BlackAreas>
 		</Camera>
-		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" supported="no">
+		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" supported="yes"> <!-- "mRaw" -->
 			<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
-			<Crop x="0" y="0" width="0" height="0"/>
-			<Sensor black="0" white="14338"/>
+			<Crop x="28" y="10" width="0" height="0"/>
+			<Sensor black="0" white="48816" iso_list="320 640 1250 2500 5000"/>
+			<Sensor black="0" white="51936" iso_list="160"/>
+			<Sensor black="0" white="55680" iso_list="400 500 800 1000 1600 2000 3200 4000 6400 12800 16000 25600"/>
+			<Sensor black="0" white="55688" iso_list="8000 10000"/>
+			<Sensor black="0" white="58832" iso_list="100 125 200 250"/>
 			<Hints>
 				<Hint name="sraw_new" value=""/>
 				<Hint name="invert_sraw_wb" value=""/>
+				<Hint name="wrapped_cr2_slices" value=""/>
 			</Hints>
 		</Camera>
-		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw2" supported="no">
+		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw2"> <!-- "sRaw" -->
 			<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
 			<Crop x="0" y="0" width="0" height="0"/>
-			<Sensor black="0" white="14338"/>
+			<Sensor black="0" white="48468" iso_list="2500"/>
+			<Sensor black="0" white="48488" iso_list="1250"/>
+			<Sensor black="0" white="48492" iso_list="320"/>
+			<Sensor black="0" white="48496" iso_list="640"/>
+			<Sensor black="0" white="48588" iso_list="5000"/>
+			<Sensor black="0" white="51932" iso_list="160"/>
+			<Sensor black="0" white="55680" iso_list="400 500 800 1000 1600 2000 3200 4000 6400 12800 16000 25600"/>
+			<Sensor black="0" white="55688" iso_list="8000 10000"/>
+			<Sensor black="0" white="58832" iso_list="100 125 200 250"/>
 			<Hints>
 				<Hint name="sraw_new" value=""/>
 				<Hint name="invert_sraw_wb" value=""/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2560,39 +2560,6 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="14bit-uncompressed">
-		<ID make="Nikon" model="D5200">Nikon D5200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="15892"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D5200">Nikon D5200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D5200">Nikon D5200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5300" mode="12bit-compressed">
 		<ID make="Nikon" model="D5300">Nikon D5300</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7977,6 +7977,18 @@
 			<Hint name="fuji_rotate" value=""/>
 		</Hints>
 	</Camera>
+	<Camera make="FUJIFILM" model="FinePix S100FS">
+		<ID make="Fujifilm" model="FinePix S100FS">Fujifilm FinePix S100FS</ID>
+		<CFA2 width="2" height="2">
+			<ColorRow y="0">GB</ColorRow>
+			<ColorRow y="1">RG</ColorRow>
+		</CFA2>
+		<Crop x="64" y="0" width="-64" height="0"/>
+		<Sensor black="512" white="16383"/>
+		<Hints>
+			<Hint name="fuji_rotate" value=""/>
+		</Hints>
+	</Camera>
 	<Camera make="FUJIFILM" model="FinePix S200EXR">
 		<ID make="Fujifilm" model="FinePix S200EXR">Fujifilm FinePix S200EXR</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3496,7 +3496,6 @@
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="1">GREEN</Color>
-
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
@@ -3505,7 +3504,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7000" mode="12bit-compressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON" model="COOLPIX P7000" mode="12bit-uncompressed" decoder_version="1">
 		<ID make="Nikon" model="Coolpix P7000">Nikon Coolpix P7000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3515,26 +3514,9 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
-		<Sensor black="250" white="4095" iso_min="400" iso_max="0"/>
+		<Sensor black="255" white="4095" iso_min="400" iso_max="3200"/>
 		<!-- In usual Nikon style, ISO 6400 is marked as ISO 0 -->
-		<Sensor black="260" white="4095" iso_min="0" iso_max="1"/>
-		<Hints>
-			<Hint name="coolpixmangled" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7000" mode="12bit-uncompressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="Coolpix P7000">Nikon Coolpix P7000</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
-		<Sensor black="250" white="4095" iso_min="400" iso_max="0"/>
-		<!-- In usual Nikon style, ISO 6400 is marked as ISO 0 -->
-		<Sensor black="260" white="4095" iso_min="0" iso_max="1"/>
+		<Sensor black="255" white="4095" iso_min="0" iso_max="1"/>
 		<Hints>
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2751,18 +2751,7 @@
 		<Crop x="0" y="0" width="-50" height="0"/>
 		<Sensor black="0" white="3880"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D70" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D70">Nikon D70</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
-		</CFA>
-		<Crop x="0" y="0" width="3038" height="2014"/>
-		<Sensor black="0" white="4095"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D70" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D70" mode="12bit-compressed">
 		<ID make="Nikon" model="D70">Nikon D70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1978,7 +1978,7 @@
 		<Crop x="2" y="0" width="4282" height="2844"/>
 		<Sensor black="0" white="3972"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-compressed">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -1986,10 +1986,10 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16384"/>
+		<Crop x="2" y="0" width="0" height="0"/>
+		<Sensor black="0" white="15520"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="14bit-uncompressed">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -1997,8 +1997,8 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16384"/>
+		<Crop x="2" y="0" width="0" height="0"/>
+		<Sensor black="0" white="15520"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-compressed">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
@@ -2008,7 +2008,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
+		<Crop x="2" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-uncompressed">
@@ -2019,7 +2019,7 @@
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
+		<Crop x="2" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3X" mode="14bit-compressed">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2186,9 +2186,6 @@
 		</CFA>
 		<Crop x="8" y="8" width="-8" height="-8"/>
 		<Sensor black="150" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3300" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D3300">Nikon D3300</ID>
@@ -2200,9 +2197,6 @@
 		</CFA>
 		<Crop x="8" y="8" width="-8" height="-8"/>
 		<Sensor black="150" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3400" mode="12bit-compressed">
 		<ID make="Nikon" model="D3400">Nikon D3400</ID>
@@ -2269,9 +2263,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="400" white="15520"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="14bit-uncompressed">
 		<ID make="Nikon" model="D5">Nikon D5</ID>
@@ -2283,9 +2274,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="400" white="15520"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-compressed">
 		<ID make="Nikon" model="D5">Nikon D5</ID>
@@ -2297,9 +2285,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="100" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D5">Nikon D5</ID>
@@ -2311,9 +2296,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="100" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-compressed">
 		<ID make="Nikon" model="Df">Nikon Df</ID>
@@ -2458,9 +2440,6 @@
 		</CFA>
 		<Crop x="2" y="2" width="-2" height="-2"/>
 		<Sensor black="400" white="15520"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D500" mode="14bit-uncompressed" supported="no">
 		<ID make="Nikon" model="D500">Nikon D500</ID>
@@ -2472,9 +2451,6 @@
 		</CFA>
 		<Crop x="2" y="2" width="-2" height="-2"/>
 		<Sensor black="400" white="15520"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D500" mode="12bit-compressed">
 		<ID make="Nikon" model="D500">Nikon D500</ID>
@@ -2486,9 +2462,6 @@
 		</CFA>
 		<Crop x="2" y="2" width="-2" height="-2"/>
 		<Sensor black="100" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D500" mode="12bit-uncompressed" supported="no">
 		<ID make="Nikon" model="D500">Nikon D500</ID>
@@ -2500,9 +2473,6 @@
 		</CFA>
 		<Crop x="2" y="2" width="-2" height="-2"/>
 		<Sensor black="100" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5000" mode="12bit-compressed">
 		<ID make="Nikon" model="D5000">Nikon D5000</ID>
@@ -2547,9 +2517,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3972"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5300" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D5300">Nikon D5300</ID>
@@ -2561,9 +2528,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3972"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5300" mode="14bit-compressed">
 		<ID make="Nikon" model="D5300">Nikon D5300</ID>
@@ -2575,9 +2539,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="600" white="15892"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5300" mode="14bit-uncompressed">
 		<ID make="Nikon" model="D5300">Nikon D5300</ID>
@@ -2589,9 +2550,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="600" white="15892"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5500" mode="12bit-compressed">
 		<ID make="Nikon" model="D5500">Nikon D5500</ID>
@@ -2603,9 +2561,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3972"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5500" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D5500">Nikon D5500</ID>
@@ -2617,9 +2572,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3972"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5500" mode="14bit-compressed">
 		<ID make="Nikon" model="D5500">Nikon D5500</ID>
@@ -2631,9 +2583,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="600" white="15892"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5500" mode="14bit-uncompressed">
 		<ID make="Nikon" model="D5500">Nikon D5500</ID>
@@ -2645,9 +2594,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="600" white="15892"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D60" mode="12bit-compressed">
 		<ID make="Nikon" model="D60">Nikon D60</ID>
@@ -2780,9 +2726,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="14bit-compressed">
 		<ID make="Nikon" model="D750">Nikon D750</ID>
@@ -2794,9 +2737,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="600" white="15520"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7000" mode="14bit-compressed">
 		<ID make="Nikon" model="D7000">Nikon D7000</ID>
@@ -2852,9 +2792,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="600" white="15892"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7200" mode="14bit-uncompressed" supported="no">
 		<ID make="Nikon" model="D7200">Nikon D7200</ID>
@@ -2866,9 +2803,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="600" white="15892"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7200" mode="12bit-compressed">
 		<ID make="Nikon" model="D7200">Nikon D7200</ID>
@@ -2880,9 +2814,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3972"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7200" mode="12bit-uncompressed" supported="no">
 		<ID make="Nikon" model="D7200">Nikon D7200</ID>
@@ -2894,9 +2825,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3972"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D70s" mode="12bit-compressed">
 		<ID make="Nikon" model="D70s">Nikon D70s</ID>
@@ -3058,7 +2986,7 @@
 		<Sensor black="150" white="3880"/>
 		<Hints>
 			<Hint name="msb_override" value=""/>
-			<Hint name="nikon_override_auto_black" value=""/>
+
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="12bit-compressed">
@@ -3071,9 +2999,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="14bit-uncompressed">
 		<ID make="Nikon" model="D810">Nikon D810</ID>
@@ -3087,7 +3012,7 @@
 		<Sensor black="600" white="15520"/>
 		<Hints>
 			<Hint name="msb_override" value=""/>
-			<Hint name="nikon_override_auto_black" value=""/>
+
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D810" mode="14bit-compressed">
@@ -3100,9 +3025,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="600" white="15520"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S" mode="sNEF-uncompressed">
 		<ID make="Nikon" model="D4S">Nikon D4S</ID>
@@ -3119,9 +3041,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="192" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D4S">Nikon D4S</ID>
@@ -3135,7 +3054,7 @@
 		<Sensor black="192" white="3880"/>
 		<Hints>
 			<Hint name="msb_override" value=""/>
-			<Hint name="nikon_override_auto_black" value=""/>
+
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S" mode="14bit-uncompressed">
@@ -3150,7 +3069,7 @@
 		<Sensor black="768" white="15520"/>
 		<Hints>
 			<Hint name="msb_override" value=""/>
-			<Hint name="nikon_override_auto_black" value=""/>
+
 		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4S" mode="14bit-compressed">
@@ -3163,9 +3082,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="768" white="15520"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D90" mode="12bit-compressed">
 		<ID make="Nikon" model="D90">Nikon D90</ID>
@@ -3243,9 +3159,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="200" white="3800"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J5" mode="12bit-uncompressed">
 		<ID make="Nikon" model="1 J5">Nikon 1 J5</ID>
@@ -3257,9 +3170,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="200" white="3800"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 S1" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 S1">Nikon 1 S1</ID>
@@ -3282,9 +3192,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="200" white="4095"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 V1" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 V1">Nikon 1 V1</ID>
@@ -3318,9 +3225,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="200" white="4000"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 V3" mode="12bit-uncompressed" decoder_version="4">
 		<ID make="Nikon" model="1 V3">Nikon 1 V3</ID>
@@ -3332,9 +3236,6 @@
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="200" white="4000"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 AW1" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 AW1">Nikon 1 AW1</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2988,17 +2988,6 @@
 		<Crop x="0" y="0" width="-46" height="-2"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D7000" mode="14bit-uncompressed">
-		<ID make="Nikon" model="D7000">Nikon D7000</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-46" height="-2"/>
-		<Sensor black="0" white="15892"/>
-	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7000" mode="12bit-compressed">
 		<ID make="Nikon" model="D7000">Nikon D7000</ID>
 		<CFA width="2" height="2">
@@ -3008,18 +2997,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-46" height="-2"/>
-		<Sensor black="0" white="4095"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D7000" mode="12bit-uncompressed">
-		<ID make="Nikon" model="D7000">Nikon D7000</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-46" height="-2"/>
-		<Sensor black="0" white="4095"/>
+		<Sensor black="0" white="3972"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7100" mode="14bit-compressed">
 		<ID make="Nikon" model="D7100">Nikon D7100</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2934,18 +2934,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D70s" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D70s">Nikon D70s</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
-		</CFA>
-		<Crop x="0" y="0" width="3040" height="2014"/>
-		<Sensor black="0" white="4095"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D70s" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D70s" mode="12bit-compressed">
 		<ID make="Nikon" model="D70s">Nikon D70s</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -633,6 +633,26 @@
 			<Hint name="invert_sraw_wb" value=""/>
 		</Hints>
 	</Camera>
+	<Camera make="Canon" model="Canon EOS 5D Mark IV">
+		<ID make="Canon" model="EOS 5D Mark IV">Canon EOS 5D Mark IV</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="136" y="44" width="0" height="0"/>
+		<Sensor black="2049" white="14448"/>
+		<Sensor black="513" white="14008" iso_list="50 100 125"/>
+		<Sensor black="512" white="10838" iso_list="160"/>
+		<Sensor black="512" white="14448" iso_list="200 250"/>
+		<Sensor black="2048" white="10838" iso_list="320 640 1250 2500 5000 10000 20000"/>
+		<Sensor black="2049" white="13533" iso_list="102400"/>
+		<BlackAreas>
+			<Vertical x="0" width="134"/>
+			<Horizontal y="0" height="40"/>
+		</BlackAreas>
+	</Camera>
 	<Camera make="Canon" model="Canon EOS 5DS" decoder_version="6">
 		<ID make="Canon" model="EOS 5DS">Canon EOS 5DS</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1796,7 +1796,7 @@
 			<Hint name="nikon_wb_adjustment" value="true"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-compressed">
 		<ID make="Nikon" model="D1H">Nikon D1H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>
@@ -1807,7 +1807,7 @@
 		<Crop x="0" y="0" width="2012" height="1324"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D1H" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D1H">Nikon D1H</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -7070,6 +7070,17 @@
 		<Crop x="0" y="0" width="-8" height="0"/>
 		<Sensor black="800" white="16300"/>
 	</Camera>
+	 <Camera make="SONY" model="DSC-RX10M3">
+		<ID make="Sony" model="DSC-RX10M3">Sony DSC-RX10M3</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-8" height="0"/>
+		<Sensor black="800" white="16300"/>
+	</Camera>
 	<!-- Still needs to interpolate/upscale some pixels -->
 	<Camera make="SIGMA" model="SIGMA dp2 Quattro" supported="no">
 		<Crop x="204" y="24" width="-236" height="-24"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3336,21 +3336,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="3300"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="1 S2">Nikon 1 S2</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="200" white="4095"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 S2">Nikon 1 S2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2385,40 +2385,7 @@
 		<Crop x="0" y="0" width="-46" height="0"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-compressed" decoder_version="2" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D3100">Nikon D3100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="8" y="2" width="-24" height="-2"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-uncompressed" decoder_version="2" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D3100">Nikon D3100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="8" y="2" width="-24" height="-2"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="12bit-compressed" decoder_version="2">
-		<ID make="Nikon" model="D3100">Nikon D3100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="8" y="2" width="-24" height="-2"/>
-		<Sensor black="0" white="3880"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="12bit-uncompressed" decoder_version="2">
 		<ID make="Nikon" model="D3100">Nikon D3100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -6724,7 +6724,7 @@
 		<Sensor black="0" white="3839"/>
 	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-70">
-		<ID make="Pentax" model="K-70">>PENTAX K-70</ID>
+		<ID make="Pentax" model="K-70">PENTAX K-70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2304,7 +2304,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-compressed">
 		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2313,12 +2313,12 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15520"/>
 		<BlackAreas>
 			<Vertical x="4984" width="8"/>
 		</BlackAreas>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="14bit-uncompressed">
 		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2327,12 +2327,12 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15520"/>
 		<BlackAreas>
 			<Vertical x="4984" width="8"/>
 		</BlackAreas>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="12bit-compressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2346,7 +2346,7 @@
 			<Vertical x="4984" width="8"/>
 		</BlackAreas>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="12bit-uncompressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON Df" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="Df">Nikon Df</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -113,10 +113,15 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="64" y="12" width="0" height="0"/>
-		<Sensor black="124" white="4000"/>
+		<Sensor black="126" white="4000"/>
+		<Sensor black="127" white="4000" iso_list="200"/>
+		<Sensor black="128" white="4000" iso_list="400"/>
+		<Sensor black="129" white="4000" iso_list="800"/>
+		<Sensor black="251" white="4000" iso_list="1600"/>
+		<Sensor black="250" white="4000" iso_list="3200"/>
 		<BlackAreas>
-			<Vertical x="0" width="60"/>
-			<Horizontal y="0" height="10"/>
+			<Vertical x="6" width="58"/>
+			<Horizontal y="4" height="8"/>
 		</BlackAreas>
 		<Aliases>
 			<Alias id="EOS Digital Rebel">Canon EOS DIGITAL REBEL</Alias>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3872,7 +3872,7 @@
 			<Hint name="real_bpp" value="16"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7800" decoder_version="5">
+	<Camera make="NIKON" model="COOLPIX P7800" mode="12bit-compressed" decoder_version="5">
 		<ID make="Nikon" model="Coolpix P7800">Nikon Coolpix P7800</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3881,7 +3881,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="3200" white="65535"/>
+		<Sensor black="3200" white="65000"/>
 		<Hints>
 			<Hint name="force_uncompressed" value=""/>
 			<Hint name="real_bpp" value="16"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3468,7 +3468,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="200" white="3800"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="14bit-compressed">
 		<ID make="Nikon" model="Coolpix A">Nikon Coolpix A</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3477,18 +3477,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-44" height="0"/>
-		<Sensor black="0" white="4095"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="Coolpix A">Nikon Coolpix A</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-44" height="0"/>
-		<Sensor black="0" white="4095"/>
+		<Sensor black="0" white="15892"/>
 	</Camera>
 	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-uncompressed" decoder_version="1">
 		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3562,7 +3562,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 V1" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 V1" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 V1">Nikon 1 V1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3571,7 +3571,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="-2"/>
-		<Sensor black="0" white="0"/>
+		<Sensor black="0" white="3300"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 V2">Nikon 1 V2</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -6741,14 +6741,14 @@
 		<Sensor black="0" white="3839"/>
 	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-70">
-		<ID make="Pentax" model="K-70">Pentax K-70</ID>
+		<ID make="Pentax" model="K-70">>PENTAX K-70</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
 			<Color x="1" y="0">GREEN</Color>
 			<Color x="0" y="1">GREEN</Color>
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
+		<Crop x="58" y="30" width="0" height="-14"/>
 		<Sensor black="64" white="16319"/>
 	</Camera>
 	<Camera make="RICOH IMAGING COMPANY, LTD." model="PENTAX K-1">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3489,18 +3489,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="3300"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="1 V2">Nikon 1 V2</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON 1 V2" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 V2">Nikon 1 V2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2372,39 +2372,6 @@
 		<Crop x="0" y="0" width="-46" height="0"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5100" mode="14bit-uncompressed" decoder_version="2">
-		<ID make="Nikon" model="D5100">Nikon D5100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-46" height="0"/>
-		<Sensor black="0" white="15892"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5100" mode="12bit-compressed" decoder_version="2" supported="no">
-		<ID make="Nikon" model="D5100">Nikon D5100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-46" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5100" mode="12bit-uncompressed" decoder_version="2" supported="no">
-		<ID make="Nikon" model="D5100">Nikon D5100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-46" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-compressed" decoder_version="2" supported="no"> <!-- need raw sample for whitelevel -->
 		<ID make="Nikon" model="D3100">Nikon D3100</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2802,9 +2802,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15520"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D610" mode="14bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D610" mode="12bit-compressed">
 		<ID make="Nikon" model="D610">Nikon D610</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2813,29 +2813,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D610" mode="12bit-compressed" supported="no">
-		<ID make="Nikon" model="D610">Nikon D610</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D610" mode="12bit-uncompressed" supported="no">
-		<ID make="Nikon" model="D610">Nikon D610</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D70" mode="12bit-compressed">
 		<ID make="Nikon" model="D70">Nikon D70</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1760,7 +1760,7 @@
 			<Hint name="wb_offset" value="142"/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D100" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D100" mode="12bit-compressed">
 		<ID make="Nikon" model="D100">Nikon D100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -1771,7 +1771,7 @@
 		<Crop x="2" y="0" width="3030" height="2024"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D100" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D100" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D100">Nikon D100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3361,18 +3361,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="1 J3">Nikon 1 J3</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="-2"/>
-		<Sensor black="0" white="4095"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 J3">Nikon 1 J3</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3364,21 +3364,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON" model="E5400" mode="12bit-compressed" decoder_version="3" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="E5400">Nikon E5400</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
-		</CFA>
-		<Crop x="0" y="0" width="2608" height="1950"/>
-		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="coolpixsplit" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON" model="E5400" mode="12bit-uncompressed" decoder_version="3" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON" model="E5400" mode="12bit-uncompressed" decoder_version="3">
 		<ID make="Nikon" model="E5400">Nikon E5400</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -411,9 +411,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="52" width="0" height="0"/>
-		<Sensor black="2026" white="13584" iso_min="0" iso_max = "199"/>
-		<Sensor black="2026" white="16383" iso_min="6400" iso_max = "25600"/>
-		<Sensor black="2026" white="15304"/>
+		<Sensor black="2052" white="15000"/>
+		<Sensor black="2048" white="12277" iso_list="100"/>
+		<Sensor black="2048" white="11222" iso_list="160 320 640 1250 2500 5000"/>
 		<BlackAreas>
 			<Vertical x="0" width="70"/>
 			<Horizontal y="4" height="50"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3222,7 +3222,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 J4">Nikon 1 J4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3231,24 +3231,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="200" white="4095"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="1 J4">Nikon 1 J4</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="200" white="4095"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
+		<Sensor black="200" white="4000"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J5" mode="12bit-compressed">
 		<ID make="Nikon" model="1 J5">Nikon 1 J5</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3507,22 +3507,7 @@
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-compressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="coolpixmangled" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-uncompressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-uncompressed" decoder_version="1">
 		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -5745,6 +5745,54 @@
 		<Crop x="0" y="0" width="-74" height="0"/>
 		<Sensor black="15" white="3971"/>
 	</Camera>
+	<Camera make="Panasonic" model="DMC-LX15">
+		<ID make="Panasonic" model="DMC-LX15">Panasonic DMC-LX9</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="143" white="4095"/>
+		<Sensor black="142" white="2095" iso_list="80"/>
+		<Sensor black="142" white="3400" iso_list="100"/>
+		<Sensor black="142" white="4095" iso_list="125"/>
+		<Sensor black="144" white="4095" iso_list="640 800"/>
+		<Sensor black="145" white="4095" iso_list="1250 1600"/>
+		<Sensor black="149" white="4095" iso_list="3200"/>
+		<Sensor black="154" white="4095" iso_list="6400"/>
+		<Sensor black="166" white="4095" iso_list="12800"/>
+		<Sensor black="167" white="4095" iso_list="25600"/>
+		<Aliases>
+			<Alias>DMC-LX9</Alias>
+			<Alias>DMC-LX10</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-LX15" mode="3:2">
+		<ID make="Panasonic" model="DMC-LX15">Panasonic DMC-LX9</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">GREEN</Color>
+			<Color x="1" y="0">BLUE</Color>
+			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="1">GREEN</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="143" white="4095"/>
+		<Sensor black="142" white="2095" iso_list="80"/>
+		<Sensor black="142" white="3400" iso_list="100"/>
+		<Sensor black="142" white="4095" iso_list="125"/>
+		<Sensor black="144" white="4095" iso_list="640 800"/>
+		<Sensor black="145" white="4095" iso_list="1250 1600"/>
+		<Sensor black="149" white="4095" iso_list="3200"/>
+		<Sensor black="154" white="4095" iso_list="6400"/>
+		<Sensor black="166" white="4095" iso_list="12800"/>
+		<Sensor black="167" white="4095" iso_list="25600"/>
+		<Aliases>
+			<Alias>DMC-LX9</Alias>
+			<Alias>DMC-LX10</Alias>
+		</Aliases>
+	</Camera>
 	<Camera make="LEICA" model="DIGILUX 2" decoder_version="2">
 		<ID make="Leica" model="Digilux 2">Leica Digilux 2</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3008,9 +3008,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D7100" mode="14bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D7100" mode="12bit-compressed">
 		<ID make="Nikon" model="D7100">Nikon D7100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3019,29 +3019,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D7100" mode="12bit-compressed" supported="no">
-		<ID make="Nikon" model="D7100">Nikon D7100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D7100" mode="12bit-uncompressed" supported="no">
-		<ID make="Nikon" model="D7100">Nikon D7100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3972"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D7200" mode="14bit-compressed">
 		<ID make="Nikon" model="D7200">Nikon D7200</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2155,7 +2155,7 @@
 		<Crop x="0" y="0" width="4320" height="2868"/>
 		<Sensor black="0" white="3808"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3000" mode="14bit-compressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D3000" mode="12bit-compressed">
 		<ID make="Nikon" model="D3000">Nikon D3000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
@@ -2164,40 +2164,7 @@
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="0" y="0" width="3898" height="2610"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3000" mode="14bit-uncompressed">
-		<ID make="Nikon" model="D3000">Nikon D3000</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="0" y="0" width="3898" height="2610"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3000" mode="12bit-compressed" supported="no">
-		<ID make="Nikon" model="D3000">Nikon D3000</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="0" y="0" width="3898" height="2610"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3000" mode="12bit-uncompressed" supported="no">
-		<ID make="Nikon" model="D3000">Nikon D3000</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="0" y="0" width="3898" height="2610"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3200" mode="12bit-compressed">
 		<ID make="Nikon" model="D3200">Nikon D3200</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3654,7 +3654,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-compressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-uncompressed" decoder_version="1">
 		<ID make="Nikon" model="Coolpix P7100">Nikon Coolpix P7100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3663,27 +3663,10 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
-		<Sensor black="250" white="4095" iso_min="400" iso_max="0"/>
+		<Sensor black="0" white="3800"/>
+		<Sensor black="250" white="3800" iso_min="400" iso_max="0"/>
 		<!-- In usual Nikon style, ISO 6400 is marked as ISO 0 -->
-		<Sensor black="260" white="4095" iso_min="0" iso_max="1"/>
-		<Hints>
-			<Hint name="coolpixmangled" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-uncompressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="Coolpix P7100">Nikon Coolpix P7100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
-		<Sensor black="250" white="4095" iso_min="400" iso_max="0"/>
-		<!-- In usual Nikon style, ISO 6400 is marked as ISO 0 -->
-		<Sensor black="260" white="4095" iso_min="0" iso_max="1"/>
+		<Sensor black="260" white="3800" iso_min="0" iso_max="1"/>
 		<Hints>
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2831,9 +2831,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15520"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D600" mode="14bit-uncompressed">
+	<Camera make="NIKON CORPORATION" model="NIKON D600" mode="12bit-compressed">
 		<ID make="Nikon" model="D600">Nikon D600</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2842,29 +2842,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D600" mode="12bit-compressed" supported="no">
-		<ID make="Nikon" model="D600">Nikon D600</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D600" mode="12bit-uncompressed" supported="no">
-		<ID make="Nikon" model="D600">Nikon D600</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-50" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D610" mode="14bit-compressed">
 		<ID make="Nikon" model="D610">Nikon D610</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3378,21 +3378,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E5700" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="E5700">Nikon E5700</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">FUJI_GREEN</Color>
-			<Color x="1" y="0">MAGENTA</Color>
-			<Color x="0" y="1">YELLOW</Color>
-			<Color x="1" y="1">CYAN</Color>
-		</CFA>
-		<Crop x="0" y="0" width="2576" height="1924"/>
-		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="coolpixsplit" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON" model="E5700" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON" model="E5700" mode="12bit-uncompressed" decoder_version="4">
 		<ID make="Nikon" model="E5700">Nikon E5700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">FUJI_GREEN</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2884,35 +2884,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="12bit-uncompressed" supported="no">
-		<ID make="Nikon" model="D750">Nikon D750</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="150" white="3880"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
-	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="14bit-compressed">
-		<ID make="Nikon" model="D750">Nikon D750</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="600" white="15520"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="14bit-uncompressed" supported="no">
 		<ID make="Nikon" model="D750">Nikon D750</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3405,7 +3405,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="3300"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J2" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J2" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 J2">Nikon 1 J2</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3414,7 +3414,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="-2"/>
-		<Sensor black="0" white="0"/>
+		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J3" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 J3">Nikon 1 J3</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3494,7 +3494,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 S1" decoder_version="4">
+	<Camera make="NIKON CORPORATION" model="NIKON 1 S1" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 S1">Nikon 1 S1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3503,7 +3503,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="-2"/>
-		<Sensor black="0" white="0"/>
+		<Sensor black="0" white="3300"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 S2" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 S2">Nikon 1 S2</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8689,6 +8689,19 @@
 		<Crop x="4" y="0" width="-52" height="0"/>
 		<Sensor black="1024" white="16383"/>
 	</Camera>
+	<Camera make="FUJIFILM" model="X-T2">
+		<ID make="Fujifilm" model="X-T2">Fujifilm X-T2</ID>
+		<CFA2 width="6" height="6">
+			<ColorRow y="0">RBGBRG</ColorRow>
+			<ColorRow y="1">GGRGGB</ColorRow>
+			<ColorRow y="2">GGBGGR</ColorRow>
+			<ColorRow y="3">BRGRBG</ColorRow>
+			<ColorRow y="4">GGBGGR</ColorRow>
+			<ColorRow y="5">GGRGGB</ColorRow>
+		</CFA2>
+		<Crop x="0" y="0" width="-126" height="0"/>
+		<Sensor black="1024" white="16383"/>
+	</Camera>
 	<Camera make="FUJIFILM" model="X-T10">
 		<ID make="Fujifilm" model="X-T10">Fujifilm X-T10</ID>
 		<CFA2 width="6" height="6">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -384,7 +384,7 @@
 				<Horizontal y="0" height="33"/>
 			</BlackAreas>
 		</Camera>
-		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" supported="yes"> <!-- "mRaw" -->
+		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1"> <!-- "mRaw" -->
 			<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
 			<Crop x="28" y="10" width="0" height="0"/>
 			<Sensor black="0" white="48816" iso_list="320 640 1250 2500 5000"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2276,7 +2276,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-compressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-compressed">
 		<ID make="Nikon" model="D5">Nikon D5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2285,12 +2285,12 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="400" white="4096"/>
+		<Sensor black="100" white="3880"/>
 		<Hints>
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-uncompressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D5">Nikon D5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2299,7 +2299,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="400" white="4096"/>
+		<Sensor black="100" white="3880"/>
 		<Hints>
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2384,6 +2384,17 @@
 		<Crop x="0" y="0" width="-46" height="0"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D5100" mode="14bit-uncompressed" decoder_version="2"> <!-- the camera lies, see https://redmine.darktable.org/issues/11268 -->
+		<ID make="Nikon" model="D5100">Nikon D5100</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-46" height="0"/>
+		<Sensor black="0" white="15892"/>
+	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="12bit-compressed" decoder_version="2">
 		<ID make="Nikon" model="D3100">Nikon D3100</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -8944,6 +8944,9 @@
 	<Camera make="RICOH" model="GR DIGITAL 2" mode="dng">
 		<ID make="Ricoh" model="GR II">Ricoh GR DIGITAL 2</ID>
 	</Camera>
+	<Camera make="Canon" model="Canon PowerShot A720 IS" mode="dng">
+		<ID make="Canon" model="PowerShot A720 IS">Canon PowerShot A720 IS</ID>
+	</Camera>
 	<Camera make="Canon" model="Canon PowerShot SX100 IS" mode="dng">
 		<ID make="Canon" model="PowerShot SX100 IS">Canon PowerShot SX100 IS</ID>
 	</Camera>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2000,7 +2000,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="16384"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-compressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-compressed">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2009,9 +2009,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-uncompressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D3S" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D3S">Nikon D3S</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2020,7 +2020,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4096"/>
+		<Sensor black="0" white="3880"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3X" mode="14bit-compressed">
 		<ID make="Nikon" model="D3X">Nikon D3X</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2204,6 +2204,17 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
+	<Camera make="NIKON CORPORATION" model="NIKON D3400" mode="12bit-compressed">
+		<ID make="Nikon" model="D3400">Nikon D3400</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="150" white="3880"/>
+	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D4" mode="14bit-compressed">
 		<ID make="Nikon" model="D4">Nikon D4</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3857,7 +3857,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7700" decoder_version="5">
+	<Camera make="NIKON" model="COOLPIX P7700" mode="12bit-compressed" decoder_version="5">
 		<ID make="Nikon" model="Coolpix P7700">Nikon Coolpix P7700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3866,7 +3866,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="3200" white="65535"/>
+		<Sensor black="3200" white="65000"/>
 		<Hints>
 			<Hint name="force_uncompressed" value=""/>
 			<Hint name="real_bpp" value="16"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -94,7 +94,12 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="72" y="52" width="0" height="0"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="2048" white="15000"/>
+		<Sensor black="2047" white="12277" iso_list="100"/>
+		<Sensor black="2047" white="15000" iso_list="200 6400"/>
+		<Sensor black="2048" white="15000" iso_list="800 3200"/>
+		<Sensor black="2049" white="15000" iso_list="1600"/>
+		<Sensor black="2046" white="15000" iso_list="25600"/>
 		<BlackAreas>
 			<Vertical x="0" width="72"/>
 			<Horizontal y="8" height="44"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1782,21 +1782,7 @@
 		<Crop x="2" y="0" width="3030" height="2024"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D1">Nikon D1</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
-		</CFA>
-		<Crop x="0" y="0" width="2000" height="1312"/>
-		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="nikon_wb_adjustment" value="true"/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D1" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D1" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D1">Nikon D1</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">BLUE</Color>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2502,18 +2502,7 @@
 			<Color x="1" y="1">RED</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-2" height="-2"/>
-		<Sensor black="0" white="3880"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D50" mode="12bit-uncompressed">
-		<ID make="Nikon" model="D50">Nikon D50</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-2" height="-2"/>
-		<Sensor black="0" white="3880"/>
+		<Sensor black="0" white="4095"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D500" mode="14bit-compressed">
 		<ID make="Nikon" model="D500">Nikon D500</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -2782,7 +2782,7 @@
 		<Crop x="2" y="0" width="4282" height="2844"/>
 		<Sensor black="0" white="3972"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-compressed">
 		<ID make="Nikon" model="D700">Nikon D700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2791,9 +2791,9 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="4282" height="2844"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON D700" mode="14bit-uncompressed">
 		<ID make="Nikon" model="D700">Nikon D700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2802,7 +2802,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="2" y="0" width="4282" height="2844"/>
-		<Sensor black="0" white="16383"/>
+		<Sensor black="0" white="15892"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="12bit-compressed">
 		<ID make="Nikon" model="D750">Nikon D750</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -5948,6 +5948,34 @@
 		<Crop x="0" y="0" width="-64" height="0"/>
 		<Sensor black="143" white="4095"/>
 	</Camera>
+	<Camera make="Panasonic" model="DMC-GX85">
+		<ID make="Panasonic" model="DMC-GX85">Panasonic DMC-GX85</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-206" height="0"/>
+		<Sensor black="143" white="4095"/>
+		<Aliases>
+			<Alias>DMC-GX80</Alias>
+		</Aliases>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-GX85" mode="4:3">
+		<ID make="Panasonic" model="DMC-GX85">Panasonic DMC-GX85</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="0" y="0" width="-206" height="0"/>
+		<Sensor black="143" white="4095"/>
+		<Aliases>
+			<Alias>DMC-GX80</Alias>
+		</Aliases>
+	</Camera>
 	<!-- Default guess -->
 	<Camera make="Panasonic" model = "DMC-LF1">
 		<ID make="Panasonic" model="DMC-LF1">Panasonic DMC-LF1</ID>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -3700,7 +3700,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P330" decoder_version="5">
+	<Camera make="NIKON" model="COOLPIX P330" mode="12bit-compressed" decoder_version="5">
 		<ID make="Nikon" model="Coolpix P330">Nikon Coolpix P330</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3709,7 +3709,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="3200" white="65535"/>
+		<Sensor black="3200" white="65000"/>
 		<Hints>
 			<Hint name="force_uncompressed" value=""/>
 			<Hint name="real_bpp" value="16"/>

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -384,7 +384,7 @@
 				<Horizontal y="0" height="33"/>
 			</BlackAreas>
 		</Camera>
-		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1"> <!-- "mRaw" -->
+		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw1" decoder_version="7">
 			<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
 			<Crop x="28" y="10" width="0" height="0"/>
 			<Sensor black="0" white="48816" iso_list="320 640 1250 2500 5000"/>
@@ -398,7 +398,7 @@
 				<Hint name="wrapped_cr2_slices" value=""/>
 			</Hints>
 		</Camera>
-		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw2"> <!-- "sRaw" -->
+		<Camera make="Canon" model="Canon EOS 80D" mode="sRaw2" decoder_version="7">
 			<ID make="Canon" model="EOS 80D">Canon EOS 80D</ID>
 			<Crop x="0" y="0" width="0" height="0"/>
 			<Sensor black="0" white="48468" iso_list="2500"/>

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -125,7 +125,7 @@
   </xs:complexType>
   <xs:simpleType name="ColorRowTypeType">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[RGB]{2,6}"/>
+      <xs:pattern value="[RGB]{2,2}([RGB]{4,4})?"/>
       <xs:minLength value="2"/>
       <xs:maxLength value="6"/>
       <xs:enumeration value="BG"/>
@@ -182,7 +182,10 @@
   </xs:simpleType>
   <xs:complexType name="CFA2Type">
     <xs:sequence>
-      <xs:element type="ColorRowType" name="ColorRow" minOccurs="2" maxOccurs="6"/>
+      <xs:choice>
+        <xs:element type="ColorRowType" name="ColorRow" minOccurs="2" maxOccurs="2"/>
+        <xs:element type="ColorRowType" name="ColorRow" minOccurs="6" maxOccurs="6"/>
+      </xs:choice>
     </xs:sequence>
     <xs:attribute type="CFA2TypeWidthType" name="width" use="required"/>
     <xs:attribute type="CFA2TypeHeightType" name="height" use="required"/>
@@ -197,12 +200,28 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+  <xs:simpleType name="IsoType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:pattern value="[0-9]{1,6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="IsoList">
+    <xs:restriction>
+      <xs:simpleType>
+        <xs:list itemType="IsoType"/>
+      </xs:simpleType>
+      <xs:minLength value="1"/>
+      <xs:maxLength value="12"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="SensorTypeIsoListType">
-    <xs:list itemType="xs:unsignedInt"/>
+    <xs:restriction base="IsoList">
+      <xs:pattern value="[0-9]{2,6}( [0-9]{3,6}){0,11}"/>
+    </xs:restriction>
   </xs:simpleType>
   <xs:attributeGroup name="SensorTypeIsoLimitsType">
-    <xs:attribute type="xs:unsignedShort" name="iso_min"/>
-    <xs:attribute type="xs:unsignedShort" name="iso_max"/>
+    <xs:attribute type="IsoType" name="iso_min"/>
+    <xs:attribute type="IsoType" name="iso_max"/>
   </xs:attributeGroup>
   <xs:complexType name="SensorType">
     <xs:simpleContent>
@@ -232,8 +251,10 @@
   </xs:complexType>
   <xs:complexType name="BlackAreasType">
     <xs:sequence>
-      <xs:element type="VerticalType" name="Vertical" minOccurs="0" maxOccurs="2"/>
-      <xs:element type="HorizontalType" name="Horizontal" minOccurs="0" maxOccurs="2"/>
+      <xs:choice minOccurs="1" maxOccurs="2">
+        <xs:element type="VerticalType" name="Vertical" minOccurs="1" maxOccurs="2"/>
+        <xs:element type="HorizontalType" name="Horizontal" minOccurs="1" maxOccurs="2"/>
+      </xs:choice>
     </xs:sequence>
   </xs:complexType>
   <xs:simpleType name="AliasTypeType">
@@ -313,7 +334,7 @@
   </xs:complexType>
   <xs:simpleType name="CameraMakeType">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[a-zA-Z ,./-]{3,27}"/>
+      <xs:pattern value="[a-zA-Z \-,./]{3,27}"/>
       <xs:minLength value="3"/>
       <xs:maxLength value="27"/>
       <xs:enumeration value="ARRI"/>

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -1,0 +1,448 @@
+<?xml version="1.0"?>
+<!--
+  License: CC-BY-SA 3.0
+
+  This work is licensed under a
+  Creative Commons Attribution-ShareAlike 3.0 Unported License.
+
+  See more at:
+  http://creativecommons.org/licenses/by-sa/3.0/
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="qualified">
+  <xs:simpleType name="IDTypeType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9 \-*()]{2,28}"/>
+      <xs:minLength value="2"/>
+      <xs:maxLength value="28"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="IDTypeMakeType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z ]{4,10}"/>
+      <xs:minLength value="4"/>
+      <xs:maxLength value="10"/>
+      <xs:enumeration value="Canon"/>
+      <xs:enumeration value="Epson"/>
+      <xs:enumeration value="Fujifilm"/>
+      <xs:enumeration value="GITUP"/>
+      <xs:enumeration value="Hasselblad"/>
+      <xs:enumeration value="Kodak"/>
+      <xs:enumeration value="Leaf"/>
+      <xs:enumeration value="Leica"/>
+      <xs:enumeration value="Mamiya"/>
+      <xs:enumeration value="Minolta"/>
+      <xs:enumeration value="Nikon"/>
+      <xs:enumeration value="Olympus"/>
+      <xs:enumeration value="OnePlus"/>
+      <xs:enumeration value="Panasonic"/>
+      <xs:enumeration value="Pentax"/>
+      <xs:enumeration value="Phase One"/>
+      <xs:enumeration value="Ricoh"/>
+      <xs:enumeration value="Samsung"/>
+      <xs:enumeration value="Sinar"/>
+      <xs:enumeration value="Sony"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="IDTypeModelType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9 \-*()]{1,22}"/>
+      <xs:minLength value="1"/>
+      <xs:maxLength value="22"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="IDType">
+    <xs:simpleContent>
+      <xs:extension base="IDTypeType">
+        <xs:attribute type="IDTypeMakeType" name="make" use="required"/>
+        <xs:attribute type="IDTypeModelType" name="model" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="ColorTypeType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Z_]{3,10}"/>
+      <xs:minLength value="3"/>
+      <xs:maxLength value="10"/>
+      <xs:enumeration value="BLUE"/>
+      <xs:enumeration value="CYAN"/>
+      <xs:enumeration value="FUJI_GREEN"/>
+      <xs:enumeration value="GREEN"/>
+      <xs:enumeration value="MAGENTA"/>
+      <xs:enumeration value="RED"/>
+      <xs:enumeration value="YELLOW"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ColorTypeXType">
+    <xs:restriction base="xs:unsignedByte">
+      <xs:pattern value="[0-2]{1,1}"/>
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="2"/>
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ColorTypeYType">
+    <xs:restriction base="xs:unsignedByte">
+      <xs:pattern value="[0-2]{1,1}"/>
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="2"/>
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ColorType">
+    <xs:simpleContent>
+      <xs:extension base="ColorTypeType">
+        <xs:attribute type="ColorTypeXType" name="x" use="required"/>
+        <xs:attribute type="ColorTypeYType" name="y" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="CFATypeWidthType">
+    <xs:restriction base="xs:unsignedByte">
+      <xs:pattern value="[2]{1,1}"/>
+      <xs:minInclusive value="2"/>
+      <xs:maxInclusive value="2"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CFATypeHeightType">
+    <xs:restriction base="xs:unsignedByte">
+      <xs:pattern value="[2]{1,1}"/>
+      <xs:minInclusive value="2"/>
+      <xs:maxInclusive value="2"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="CFAType">
+    <xs:sequence>
+      <xs:element type="ColorType" name="Color" minOccurs="4" maxOccurs="4"/>
+    </xs:sequence>
+    <xs:attribute type="CFATypeWidthType" name="width" use="required"/>
+    <xs:attribute type="CFATypeHeightType" name="height" use="required"/>
+  </xs:complexType>
+  <xs:simpleType name="ColorRowTypeType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[RGB]{2,6}"/>
+      <xs:minLength value="2"/>
+      <xs:maxLength value="6"/>
+      <xs:enumeration value="BG"/>
+      <xs:enumeration value="BGBRGR"/>
+      <xs:enumeration value="BRGRBG"/>
+      <xs:enumeration value="GB"/>
+      <xs:enumeration value="GBGGRG"/>
+      <xs:enumeration value="GGBGGR"/>
+      <xs:enumeration value="GGRGGB"/>
+      <xs:enumeration value="GR"/>
+      <xs:enumeration value="GRGGBG"/>
+      <xs:enumeration value="RBGBRG"/>
+      <xs:enumeration value="RG"/>
+      <xs:enumeration value="RGRBGB"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ColorRowTypeTypeYType">
+    <xs:restriction base="xs:unsignedByte">
+      <xs:pattern value="[0-6]{1,1}"/>
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="6"/>
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+      <xs:enumeration value="3"/>
+      <xs:enumeration value="4"/>
+      <xs:enumeration value="5"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ColorRowType">
+    <xs:simpleContent>
+      <xs:extension base="ColorRowTypeType">
+        <xs:attribute type="ColorRowTypeTypeYType" name="y" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="CFA2TypeWidthType">
+    <xs:restriction base="xs:unsignedByte">
+      <xs:pattern value="[26]{1,1}"/>
+      <xs:minInclusive value="2"/>
+      <xs:maxInclusive value="6"/>
+      <xs:enumeration value="2"/>
+      <xs:enumeration value="6"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CFA2TypeHeightType">
+    <xs:restriction base="xs:unsignedByte">
+      <xs:pattern value="[26]{1,1}"/>
+      <xs:minInclusive value="2"/>
+      <xs:maxInclusive value="6"/>
+      <xs:enumeration value="2"/>
+      <xs:enumeration value="6"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="CFA2Type">
+    <xs:sequence>
+      <xs:element type="ColorRowType" name="ColorRow" minOccurs="2" maxOccurs="6"/>
+    </xs:sequence>
+    <xs:attribute type="CFA2TypeWidthType" name="width" use="required"/>
+    <xs:attribute type="CFA2TypeHeightType" name="height" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="CropType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:unsignedShort" name="x" use="required"/>
+        <xs:attribute type="xs:unsignedByte" name="y" use="required"/>
+        <xs:attribute type="xs:short" name="width" use="required"/>
+        <xs:attribute type="xs:short" name="height" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="SensorTypeIsoListType">
+    <xs:list itemType="xs:unsignedInt"/>
+  </xs:simpleType>
+  <xs:attributeGroup name="SensorTypeIsoLimitsType">
+    <xs:attribute type="xs:unsignedShort" name="iso_min"/>
+    <xs:attribute type="xs:unsignedShort" name="iso_max"/>
+  </xs:attributeGroup>
+  <xs:complexType name="SensorType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:unsignedShort" name="black" use="required"/>
+        <xs:attribute type="xs:unsignedShort" name="white" use="required"/>
+        <xs:attribute type="SensorTypeIsoListType" name="iso_list"/>
+        <xs:attributeGroup ref="SensorTypeIsoLimitsType"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="VerticalType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:unsignedShort" name="x" use="required"/>
+        <xs:attribute type="xs:unsignedShort" name="width" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="HorizontalType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:unsignedShort" name="y" use="required"/>
+        <xs:attribute type="xs:unsignedByte" name="height" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="BlackAreasType">
+    <xs:sequence>
+      <xs:element type="VerticalType" name="Vertical" minOccurs="0" maxOccurs="2"/>
+      <xs:element type="HorizontalType" name="Horizontal" minOccurs="0" maxOccurs="2"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="AliasTypeType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9 \-,]{6,27}"/>
+      <xs:minLength value="6"/>
+      <xs:maxLength value="27"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AliasTypeIdType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9 \-]{7,21}"/>
+      <xs:minLength value="7"/>
+      <xs:maxLength value="21"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AliasType">
+    <xs:simpleContent>
+      <xs:extension base="AliasTypeType">
+        <xs:attribute type="AliasTypeIdType" name="id"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AliasesType">
+    <xs:sequence>
+      <xs:element type="AliasType" name="Alias" minOccurs="1" maxOccurs="4"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="HintTypeNameType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9_]{6,26}"/>
+      <xs:minLength value="6"/>
+      <xs:maxLength value="26"/>
+      <xs:enumeration value="coolpixmangled"/>
+      <xs:enumeration value="coolpixsplit"/>
+      <xs:enumeration value="double_line_ljpeg"/>
+      <xs:enumeration value="double_width_unpacked"/>
+      <xs:enumeration value="easyshare_offset_hack"/>
+      <xs:enumeration value="filesize"/>
+      <xs:enumeration value="force_uncompressed"/>
+      <xs:enumeration value="fuji_rotate"/>
+      <xs:enumeration value="full_height"/>
+      <xs:enumeration value="full_width"/>
+      <xs:enumeration value="invert_sraw_wb"/>
+      <xs:enumeration value="jpeg32_bitorder"/>
+      <xs:enumeration value="msb_override"/>
+      <xs:enumeration value="nikon_override_auto_black"/>
+      <xs:enumeration value="nikon_wb_adjustment"/>
+      <xs:enumeration value="no_decompressed_lowbits"/>
+      <xs:enumeration value="offset"/>
+      <xs:enumeration value="old_format"/>
+      <xs:enumeration value="packed_with_control"/>
+      <xs:enumeration value="pixel_aspect_ratio"/>
+      <xs:enumeration value="real_bpp"/>
+      <xs:enumeration value="sr2_format"/>
+      <xs:enumeration value="sraw_40d"/>
+      <xs:enumeration value="sraw_new"/>
+      <xs:enumeration value="srf_format"/>
+      <xs:enumeration value="swapped_wb"/>
+      <xs:enumeration value="wb_mangle"/>
+      <xs:enumeration value="wb_offset"/>
+      <xs:enumeration value="wrapped_cr2_slices"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="HintType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="HintTypeNameType" name="name" use="required"/>
+        <xs:attribute type="xs:string" name="value" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="HintsType">
+    <xs:sequence>
+      <xs:element type="HintType" name="Hint" minOccurs="1" maxOccurs="4"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="CameraMakeType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z ,./-]{3,27}"/>
+      <xs:minLength value="3"/>
+      <xs:maxLength value="27"/>
+      <xs:enumeration value="ARRI"/>
+      <xs:enumeration value="AVT"/>
+      <xs:enumeration value="AgfaPhoto"/>
+      <xs:enumeration value="Alcatel"/>
+      <xs:enumeration value="Baumer"/>
+      <xs:enumeration value="Canon"/>
+      <xs:enumeration value="Casio"/>
+      <xs:enumeration value="Creative"/>
+      <xs:enumeration value="Creo/Leaf"/>
+      <xs:enumeration value="DJI"/>
+      <xs:enumeration value="EASTMAN KODAK COMPANY"/>
+      <xs:enumeration value="FUJIFILM"/>
+      <xs:enumeration value="Foculus"/>
+      <xs:enumeration value="GITUP"/>
+      <xs:enumeration value="Generic"/>
+      <xs:enumeration value="Hasselblad"/>
+      <xs:enumeration value="KODAK"/>
+      <xs:enumeration value="KONICA MINOLTA"/>
+      <xs:enumeration value="Kodak"/>
+      <xs:enumeration value="Konica Minolta Camera, Inc."/>
+      <xs:enumeration value="LEICA"/>
+      <xs:enumeration value="Leaf"/>
+      <xs:enumeration value="Leica Camera AG"/>
+      <xs:enumeration value="Mamiya-OP Co.,Ltd."/>
+      <xs:enumeration value="Matrix"/>
+      <xs:enumeration value="Micron"/>
+      <xs:enumeration value="Minolta Co., Ltd."/>
+      <xs:enumeration value="Minolta"/>
+      <xs:enumeration value="NIKON CORPORATION"/>
+      <xs:enumeration value="NIKON"/>
+      <xs:enumeration value="Nikon"/>
+      <xs:enumeration value="OLYMPUS CORPORATION"/>
+      <xs:enumeration value="OLYMPUS IMAGING CORP."/>
+      <xs:enumeration value="OLYMPUS OPTICAL CO.,LTD"/>
+      <xs:enumeration value="Olympus"/>
+      <xs:enumeration value="OnePlus"/>
+      <xs:enumeration value="PENTAX Corporation"/>
+      <xs:enumeration value="PENTAX RICOH IMAGING"/>
+      <xs:enumeration value="PENTAX"/>
+      <xs:enumeration value="Panasonic"/>
+      <xs:enumeration value="Pentax"/>
+      <xs:enumeration value="Phase One A/S"/>
+      <xs:enumeration value="Pixelink"/>
+      <xs:enumeration value="RICOH IMAGING COMPANY, LTD."/>
+      <xs:enumeration value="RICOH"/>
+      <xs:enumeration value="RoverShot"/>
+      <xs:enumeration value="SAMSUNG DIGITAL IMA"/>
+      <xs:enumeration value="SAMSUNG"/>
+      <xs:enumeration value="SEIKO EPSON CORP."/>
+      <xs:enumeration value="SIGMA"/>
+      <xs:enumeration value="SONY"/>
+      <xs:enumeration value="ST Micro"/>
+      <xs:enumeration value="Samsung"/>
+      <xs:enumeration value="Sinar Photography AG"/>
+      <xs:enumeration value="Sinar"/>
+      <xs:enumeration value="Sony"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CameraModelType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9 \-().,/*]{0,51}"/>
+      <xs:minLength value="0"/>
+      <xs:maxLength value="51"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CameraTypeModeType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z0-9:\-x]{3,29}"/>
+      <xs:minLength value="3"/>
+      <xs:maxLength value="29"/>
+      <xs:enumeration value="12bit"/>
+      <xs:enumeration value="12bit-compressed"/>
+      <xs:enumeration value="12bit-uncompressed"/>
+      <xs:enumeration value="14bit-compressed"/>
+      <xs:enumeration value="14bit-uncompressed"/>
+      <xs:enumeration value="16:9"/>
+      <xs:enumeration value="1:1"/>
+      <xs:enumeration value="3:2"/>
+      <xs:enumeration value="4:3"/>
+      <xs:enumeration value="7424x4924-14bit-uncompressed"/>
+      <xs:enumeration value="chdk"/>
+      <xs:enumeration value="chdk-a"/>
+      <xs:enumeration value="chdk-b"/>
+      <xs:enumeration value="chdk-c"/>
+      <xs:enumeration value="chdk-d"/>
+      <xs:enumeration value="dng"/>
+      <xs:enumeration value="sNEF-uncompressed"/>
+      <xs:enumeration value="sRaw1"/>
+      <xs:enumeration value="sRaw2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CameraTypeSupportedType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="no"/>
+      <xs:minLength value="2"/>
+      <xs:maxLength value="2"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="CameraType">
+    <xs:sequence>
+      <xs:element type="IDType" name="ID" minOccurs="0" maxOccurs="1"/>
+      <xs:choice>
+        <xs:element type="CFAType" name="CFA" minOccurs="0" maxOccurs="1"/>
+        <xs:element type="CFA2Type" name="CFA2" minOccurs="0" maxOccurs="1"/>
+      </xs:choice>
+      <xs:element type="CropType" name="Crop" minOccurs="0" maxOccurs="1"/>
+      <xs:element type="SensorType" name="Sensor" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element type="BlackAreasType" name="BlackAreas" minOccurs="0" maxOccurs="1"/>
+      <xs:element type="AliasesType" name="Aliases" minOccurs="0" maxOccurs="1"/>
+      <xs:element type="HintsType" name="Hints" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute type="CameraMakeType" name="make" use="required"/>
+    <xs:attribute type="CameraModelType" name="model" use="required"/>
+    <xs:attribute type="xs:unsignedByte" name="decoder_version"/>
+    <xs:attribute type="CameraTypeModeType" name="mode"/>
+    <xs:attribute type="CameraTypeSupportedType" name="supported"/>
+  </xs:complexType>
+  <xs:complexType name="CamerasType">
+    <xs:sequence>
+      <xs:element type="CameraType" name="Camera" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="Cameras" type="CamerasType"/>
+</xs:schema>
+<!--
+vim: tabstop=2 shiftwidth=2 softtabstop=2 expandtab
+kate: tab-width: 2; indent-width 2; replace-tabs on; tab-indents: off;
+kate: indent-mode xml; remove-trailing-spaces modified;
+-->

--- a/data/cameras.xsd
+++ b/data/cameras.xsd
@@ -301,7 +301,6 @@
       <xs:enumeration value="invert_sraw_wb"/>
       <xs:enumeration value="jpeg32_bitorder"/>
       <xs:enumeration value="msb_override"/>
-      <xs:enumeration value="nikon_override_auto_black"/>
       <xs:enumeration value="nikon_wb_adjustment"/>
       <xs:enumeration value="no_decompressed_lowbits"/>
       <xs:enumeration value="offset"/>


### PR DESCRIPTION
All right, i guess it is time for a sync again.

Gist:
- Shitload of **Nikon** white-level fixes.
- Fixes for building with with **libjpeg** (as opposed to **libjpeg-turbo**)
- **XSD** for `cameras.xml`. Will allow us in darktable to do some better checks during CI. Would have prevented `Remove stray ">" in PENTAX K-70 ID.`
- `nikon_override_auto_black` hint is no more needed, and was removed.
- **Heap-allocate** big things that were stack-allocated before. Was part of cleanup to support running darktable on `musl libc`.
- Some more camera support, highlights:
  - **Canon EOS 5D Mark IV**, only full raw, i did not get m/s RAW samples yet. 
  - **Canon EOS 80D m/s RAW** support, same as https://github.com/klauspost/rawspeed/pull/161 
- A few white level fixes for Canon :(
- A bit of **undefined behavior** fixes
- Add missing `Throw` in `RawDecoder::setMetaData()` if no `cam`. Prevents loading of broken images when guessing (`failOnUnknown`) is disabled.

Now what this does not fix:
These 3 cameras got disabled:
```
Camera ["NIKON CORPORATION", "NIKON D3X", "12bit-compressed"] has too high white level: 4096 (>= ((2^12)-1), which is 4095)
Camera ["NIKON CORPORATION", "NIKON D3X", "12bit-uncompressed"] has too high white level: 4096 (>= ((2^12)-1), which is 4095)
Camera ["NIKON", "E8400", "12bit-compressed"] has too high white level: 4095 (>= ((2^12)-1), which is 4095)
Camera ["NIKON", "E8400", "12bit-uncompressed"] has too high white level: 4095 (>= ((2^12)-1), which is 4095)
Camera ["NIKON", "E8800", "12bit-compressed"] has too high white level: 4095 (>= ((2^12)-1), which is 4095)
Camera ["NIKON", "E8800", "12bit-uncompressed"] has too high white level: 4095 (>= ((2^12)-1), which is 4095)
```
They can be trivially re-enabled after a raw sample for each is found, to check white levels.
Not sure, should i enable them in this pr, for upstreaming? May complicate upstreaming later on.

And, it was found that `NIKON D5100` is lying (duh), in this case it marks compressed raws as uncompressed, https://redmine.darktable.org/issues/11268, or at least it seems so.

Special thanks to @schenlap.