### PR TITLE
Document that darktable-org/rawspeed is now the upstream.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+# WARNING: rawspeed is now maintained under [darktable-org/rawspeed](https://github.com/darktable-org/rawspeed) repo! Do **NOT** open new issues in this old repo! Do **NOT** send new pull requests to this old repo!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,1 @@
+# WARNING: rawspeed is now maintained under [darktable-org/rawspeed](https://github.com/darktable-org/rawspeed) repo! Do **NOT** open new issues in this old repo! Do **NOT** send new pull requests to this old repo!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+# WARNING: rawspeed is now maintained under [darktable-org/rawspeed](https://github.com/darktable-org/rawspeed) repo! Do **NOT** open new issues in this old repo! Do **NOT** send new pull requests to this old repo!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# WARNING: rawspeed is now maintained under [darktable-org/rawspeed](https://github.com/darktable-org/rawspeed) repo! Do **NOT** open new issues in this old repo! Do **NOT** send new pull requests to this old repo!
+
+---
+
 #RawSpeed Developer Information
 
 ##What is RawSpeed?


### PR DESCRIPTION
Hi, @klauspost !
Now that we are more or less adjusted, i think it may be time to publicly announce it.
(no, this is not a fork, that was klaus's decision)